### PR TITLE
Add basic hexagonal health check APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>system</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>system</name>
+    <description>Hexagonal architecture base with health checks</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/system/SystemApplication.java
+++ b/src/main/java/com/example/system/SystemApplication.java
@@ -1,0 +1,11 @@
+package com.example.system;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SystemApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SystemApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/system/adapter/in/web/DbHealthCheckReq.java
+++ b/src/main/java/com/example/system/adapter/in/web/DbHealthCheckReq.java
@@ -1,0 +1,3 @@
+package com.example.system.adapter.in.web;
+
+public record DbHealthCheckReq() {}

--- a/src/main/java/com/example/system/adapter/in/web/HealthCheckRes.java
+++ b/src/main/java/com/example/system/adapter/in/web/HealthCheckRes.java
@@ -1,0 +1,3 @@
+package com.example.system.adapter.in.web;
+
+public record HealthCheckRes(String status) {}

--- a/src/main/java/com/example/system/adapter/in/web/HealthCheckWebCtr.java
+++ b/src/main/java/com/example/system/adapter/in/web/HealthCheckWebCtr.java
@@ -1,0 +1,27 @@
+package com.example.system.adapter.in.web;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.system.application.port.in.HealthCheckUseCase;
+import com.example.system.application.port.in.ServerHealthCheckCommand;
+import com.example.system.application.port.in.DbHealthCheckCommand;
+
+@RestController
+@RequestMapping("/health")
+@RequiredArgsConstructor
+public class HealthCheckWebCtr {
+    private final HealthCheckUseCase useCase;
+
+    @GetMapping("/server")
+    public HealthCheckRes server(ServerHealthCheckReq req) {
+        return useCase.checkServerHealth(new ServerHealthCheckCommand());
+    }
+
+    @GetMapping("/db")
+    public HealthCheckRes db(DbHealthCheckReq req) {
+        return useCase.checkDbHealth(new DbHealthCheckCommand());
+    }
+}

--- a/src/main/java/com/example/system/adapter/in/web/ServerHealthCheckReq.java
+++ b/src/main/java/com/example/system/adapter/in/web/ServerHealthCheckReq.java
@@ -1,0 +1,3 @@
+package com.example.system.adapter.in.web;
+
+public record ServerHealthCheckReq() {}

--- a/src/main/java/com/example/system/adapter/out/persistence/DbHealthCheckAdapter.java
+++ b/src/main/java/com/example/system/adapter/out/persistence/DbHealthCheckAdapter.java
@@ -1,0 +1,24 @@
+package com.example.system.adapter.out.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import com.example.system.adapter.out.persistence.repository.HealthCheckRepository;
+import com.example.system.application.port.out.DbHealthCheckOutCommand;
+import com.example.system.application.port.out.DbHealthCheckPort;
+
+@Component
+@RequiredArgsConstructor
+public class DbHealthCheckAdapter implements DbHealthCheckPort {
+    private final HealthCheckRepository repository;
+
+    @Override
+    public boolean check(DbHealthCheckOutCommand command) {
+        try {
+            Integer result = repository.selectHealth();
+            return result != null && result == 1;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/system/adapter/out/persistence/repository/HealthCheckRepository.java
+++ b/src/main/java/com/example/system/adapter/out/persistence/repository/HealthCheckRepository.java
@@ -1,0 +1,8 @@
+package com.example.system.adapter.out.persistence.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface HealthCheckRepository {
+    Integer selectHealth();
+}

--- a/src/main/java/com/example/system/application/port/in/DbHealthCheckCommand.java
+++ b/src/main/java/com/example/system/application/port/in/DbHealthCheckCommand.java
@@ -1,0 +1,3 @@
+package com.example.system.application.port.in;
+
+public record DbHealthCheckCommand() {}

--- a/src/main/java/com/example/system/application/port/in/HealthCheckUseCase.java
+++ b/src/main/java/com/example/system/application/port/in/HealthCheckUseCase.java
@@ -1,0 +1,8 @@
+package com.example.system.application.port.in;
+
+import com.example.system.adapter.in.web.HealthCheckRes;
+
+public interface HealthCheckUseCase {
+    HealthCheckRes checkServerHealth(ServerHealthCheckCommand command);
+    HealthCheckRes checkDbHealth(DbHealthCheckCommand command);
+}

--- a/src/main/java/com/example/system/application/port/in/ServerHealthCheckCommand.java
+++ b/src/main/java/com/example/system/application/port/in/ServerHealthCheckCommand.java
@@ -1,0 +1,3 @@
+package com.example.system.application.port.in;
+
+public record ServerHealthCheckCommand() {}

--- a/src/main/java/com/example/system/application/port/out/DbHealthCheckOutCommand.java
+++ b/src/main/java/com/example/system/application/port/out/DbHealthCheckOutCommand.java
@@ -1,0 +1,3 @@
+package com.example.system.application.port.out;
+
+public record DbHealthCheckOutCommand() {}

--- a/src/main/java/com/example/system/application/port/out/DbHealthCheckPort.java
+++ b/src/main/java/com/example/system/application/port/out/DbHealthCheckPort.java
@@ -1,0 +1,5 @@
+package com.example.system.application.port.out;
+
+public interface DbHealthCheckPort {
+    boolean check(DbHealthCheckOutCommand command);
+}

--- a/src/main/java/com/example/system/application/service/HealthCheckService.java
+++ b/src/main/java/com/example/system/application/service/HealthCheckService.java
@@ -1,0 +1,28 @@
+package com.example.system.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import com.example.system.adapter.in.web.HealthCheckRes;
+import com.example.system.application.port.in.DbHealthCheckCommand;
+import com.example.system.application.port.in.HealthCheckUseCase;
+import com.example.system.application.port.in.ServerHealthCheckCommand;
+import com.example.system.application.port.out.DbHealthCheckOutCommand;
+import com.example.system.application.port.out.DbHealthCheckPort;
+
+@Service
+@RequiredArgsConstructor
+public class HealthCheckService implements HealthCheckUseCase {
+    private final DbHealthCheckPort dbHealthCheckPort;
+
+    @Override
+    public HealthCheckRes checkServerHealth(ServerHealthCheckCommand command) {
+        return new HealthCheckRes("OK");
+    }
+
+    @Override
+    public HealthCheckRes checkDbHealth(DbHealthCheckCommand command) {
+        boolean ok = dbHealthCheckPort.check(new DbHealthCheckOutCommand());
+        return new HealthCheckRes(ok ? "OK" : "FAIL");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  sql:
+    init:
+      mode: never
+mybatis:
+  mapper-locations: classpath:mybatis/**/*.xml

--- a/src/main/resources/mybatis/system/HealthCheckRepository.xml
+++ b/src/main/resources/mybatis/system/HealthCheckRepository.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.system.adapter.out.persistence.repository.HealthCheckRepository">
+  <select id="selectHealth" resultType="int">
+    SELECT 1
+  </select>
+</mapper>


### PR DESCRIPTION
## Summary
- set up Spring Boot hexagonal project structure
- add server and database health check endpoints
- implement MyBatis adapter for DB connectivity check

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba911796f0832eb0e723632aa3ad8a