### PR TITLE
Add object API and improve documentation

### DIFF
--- a/src/main/java/com/rbox/auth/adapter/in/web/AuthWebCtr.java
+++ b/src/main/java/com/rbox/auth/adapter/in/web/AuthWebCtr.java
@@ -14,17 +14,30 @@ import com.rbox.auth.application.port.in.RefreshCommand;
 import com.rbox.auth.application.port.in.TokenResp;
 import com.rbox.common.api.ApiResponse;
 
+/**
+ * 인증 관련 API를 처리하는 Web Controller.
+ */
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthWebCtr {
     private final AuthUseCase useCase;
 
+    /**
+     * 로그인 API.
+     * <p>필수 입력: 이메일(email), 비밀번호(password)</p>
+     * <p>출력: access/refresh 토큰이 포함된 {@link TokenResp}</p>
+     */
     @PostMapping("/login")
     public ApiResponse<TokenResp> login(@Valid @RequestBody LoginReq req) {
         return ApiResponse.success(useCase.login(new LoginCommand(req.email(), req.password())));
     }
 
+    /**
+     * 토큰 갱신 API.
+     * <p>필수 입력: refreshToken</p>
+     * <p>출력: 새로운 access 토큰이 포함된 {@link TokenResp}</p>
+     */
     @PostMapping("/refresh")
     public ApiResponse<TokenResp> refresh(@Valid @RequestBody RefreshReq req) {
         return ApiResponse.success(useCase.refresh(new RefreshCommand(req.refreshToken())));

--- a/src/main/java/com/rbox/auth/application/service/AuthService.java
+++ b/src/main/java/com/rbox/auth/application/service/AuthService.java
@@ -11,11 +11,20 @@ import com.rbox.common.api.ErrorCode;
 import com.rbox.common.exception.ApiException;
 import com.rbox.user.adapter.out.persistence.repository.UserRepository;
 
+/**
+ * 인증 도메인 로직을 처리하는 서비스.
+ */
 @Service
 @RequiredArgsConstructor
 public class AuthService implements AuthUseCase {
     private final UserRepository repository;
 
+    /**
+     * 사용자의 로그인 요청을 처리한다.
+     *
+     * @param command 로그인 정보(email, password)
+     * @return 발급된 토큰 응답
+     */
     @Override
     public TokenResp login(LoginCommand command) {
         var user = repository.findByEmail(command.email());
@@ -25,6 +34,12 @@ public class AuthService implements AuthUseCase {
         throw new ApiException(ErrorCode.UNAUTHORIZED, "invalid credentials");
     }
 
+    /**
+     * refresh 토큰으로 access 토큰을 재발급한다.
+     *
+     * @param command refresh 토큰 정보
+     * @return 새롭게 발급된 토큰 응답
+     */
     @Override
     public TokenResp refresh(RefreshCommand command) {
         if ("REFRESH_TOKEN".equals(command.refreshToken())) {

--- a/src/main/java/com/rbox/object/adapter/in/web/ObjectCreateReq.java
+++ b/src/main/java/com/rbox/object/adapter/in/web/ObjectCreateReq.java
@@ -1,0 +1,7 @@
+package com.rbox.object.adapter.in.web;
+
+/**
+ * 개체 생성 요청 DTO.
+ */
+public record ObjectCreateReq(String spcCd, String name, String sexCd, String bthYmd) {}
+

--- a/src/main/java/com/rbox/object/adapter/in/web/ObjectImageReq.java
+++ b/src/main/java/com/rbox/object/adapter/in/web/ObjectImageReq.java
@@ -1,0 +1,7 @@
+package com.rbox.object.adapter.in.web;
+
+/**
+ * 개체 이미지 추가 요청 DTO.
+ */
+public record ObjectImageReq(String url, int ordNo) {}
+

--- a/src/main/java/com/rbox/object/adapter/in/web/ObjectUpdateReq.java
+++ b/src/main/java/com/rbox/object/adapter/in/web/ObjectUpdateReq.java
@@ -1,0 +1,7 @@
+package com.rbox.object.adapter.in.web;
+
+/**
+ * 개체 수정 요청 DTO.
+ */
+public record ObjectUpdateReq(String name, String sexCd, String bthYmd) {}
+

--- a/src/main/java/com/rbox/object/adapter/in/web/ObjectWebCtr.java
+++ b/src/main/java/com/rbox/object/adapter/in/web/ObjectWebCtr.java
@@ -1,0 +1,111 @@
+package com.rbox.object.adapter.in.web;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+import com.rbox.object.adapter.out.persistence.repository.ObjectEntity;
+import com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity;
+import com.rbox.object.application.port.in.AddImageCommand;
+import com.rbox.object.application.port.in.CreateObjectCommand;
+import com.rbox.object.application.port.in.ObjectUseCase;
+import com.rbox.object.application.port.in.UpdateObjectCommand;
+
+/**
+ * 개체(Object) 관련 API를 제공하는 Web Controller.
+ */
+@RestController
+@RequestMapping("/objects")
+@RequiredArgsConstructor
+public class ObjectWebCtr {
+    private final ObjectUseCase useCase;
+
+    /**
+     * 심플 모드 개체 생성 API.
+     * <p>필수 입력: spcCd, sexCd(M/F/U)</p>
+     * <p>출력: 생성된 개체 ID</p>
+     */
+    @PostMapping
+    public ApiResponse<Map<String, Long>> create(@Valid @RequestBody ObjectCreateReq req) {
+        Long id = useCase.createObject(new CreateObjectCommand(req.spcCd(), req.name(), req.sexCd(), req.bthYmd()), 1L);
+        Map<String, Long> data = new HashMap<>();
+        data.put("id", id);
+        return ApiResponse.success(data);
+    }
+
+    /**
+     * 내 개체 목록 조회 API.
+     * <p>출력: 소유한 개체 리스트</p>
+     */
+    @GetMapping
+    public ApiResponse<List<ObjectEntity>> list() {
+        return ApiResponse.success(useCase.listObjects(1L));
+    }
+
+    /**
+     * 개체 상세 조회 API.
+     * <p>필수 입력: 개체 ID</p>
+     */
+    @GetMapping("/{id}")
+    public ApiResponse<ObjectEntity> get(@PathVariable Long id) {
+        return ApiResponse.success(useCase.getObject(id, 1L));
+    }
+
+    /**
+     * 개체 정보 수정 API.
+     */
+    @PatchMapping("/{id}")
+    public ApiResponse<Void> update(@PathVariable Long id, @Valid @RequestBody ObjectUpdateReq req) {
+        useCase.updateObject(id, new UpdateObjectCommand(req.name(), req.sexCd(), req.bthYmd()), 1L);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 개체 삭제 API.
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable Long id) {
+        useCase.deleteObject(id, 1L);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 개체 이미지 목록 조회 API.
+     */
+    @GetMapping("/{id}/images")
+    public ApiResponse<List<ObjectImageEntity>> listImages(@PathVariable Long id) {
+        return ApiResponse.success(useCase.listImages(id, 1L));
+    }
+
+    /**
+     * 개체 이미지 추가 API.
+     */
+    @PostMapping("/{id}/images")
+    public ApiResponse<Map<String, Long>> addImage(@PathVariable Long id, @Valid @RequestBody ObjectImageReq req) {
+        Long imgId = useCase.addImage(id, new AddImageCommand(req.url(), req.ordNo()), 1L);
+        return ApiResponse.success(Map.of("imgId", imgId));
+    }
+
+    /**
+     * 개체 이미지 삭제 API.
+     */
+    @DeleteMapping("/{id}/images/{imgId}")
+    public ApiResponse<Void> deleteImage(@PathVariable Long id, @PathVariable Long imgId) {
+        useCase.deleteImage(id, imgId, 1L);
+        return ApiResponse.success(null);
+    }
+}
+

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectImageRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectImageRepository.java
@@ -1,0 +1,39 @@
+package com.rbox.object.adapter.out.persistence.repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Repository;
+
+/**
+ * 메모리에 개체 이미지를 저장하는 테스트용 구현체.
+ */
+@Repository
+public class InMemoryObjectImageRepository implements ObjectImageRepository {
+    private final Map<Long, List<ObjectImageEntity>> store = new HashMap<>();
+    private final AtomicLong seq = new AtomicLong(1);
+
+    @Override
+    public Long save(ObjectImageEntity entity) {
+        Long id = seq.getAndIncrement();
+        ObjectImageEntity saved = new ObjectImageEntity(id, entity.objId(), entity.url(), entity.ordNo());
+        store.computeIfAbsent(entity.objId(), k -> new ArrayList<>()).add(saved);
+        return id;
+    }
+
+    @Override
+    public List<ObjectImageEntity> findByObjectId(Long objId) {
+        return store.getOrDefault(objId, new ArrayList<>());
+    }
+
+    @Override
+    public void delete(Long imgId) {
+        for (List<ObjectImageEntity> list : store.values()) {
+            list.removeIf(img -> img.imgId().equals(imgId));
+        }
+    }
+}
+

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectRepository.java
@@ -1,0 +1,54 @@
+package com.rbox.object.adapter.out.persistence.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Repository;
+
+/**
+ * 메모리에 개체 정보를 저장하는 테스트용 구현체.
+ */
+@Repository
+public class InMemoryObjectRepository implements ObjectRepository {
+    private final Map<Long, ObjectEntity> store = new ConcurrentHashMap<>();
+    private final AtomicLong seq = new AtomicLong(1);
+
+    @Override
+    public Long save(ObjectEntity entity) {
+        Long id = seq.getAndIncrement();
+        store.put(id, new ObjectEntity(id, entity.spcCd(), entity.name(), entity.sexCd(), entity.bthYmd(),
+                entity.objMode(), entity.statCd(), entity.marketOk(), entity.ownUsrId()));
+        return id;
+    }
+
+    @Override
+    public Optional<ObjectEntity> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public List<ObjectEntity> findByOwner(Long ownerId) {
+        List<ObjectEntity> list = new ArrayList<>();
+        for (ObjectEntity e : store.values()) {
+            if (ownerId.equals(e.ownUsrId())) {
+                list.add(e);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public void update(ObjectEntity entity) {
+        store.put(entity.id(), entity);
+    }
+
+    @Override
+    public void delete(Long id) {
+        store.remove(id);
+    }
+}
+

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectEntity.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectEntity.java
@@ -1,0 +1,17 @@
+package com.rbox.object.adapter.out.persistence.repository;
+
+/**
+ * 개체(Object) 정보를 보관하는 엔티티.
+ */
+public record ObjectEntity(
+        Long id,
+        String spcCd,
+        String name,
+        String sexCd,
+        String bthYmd,
+        String objMode,
+        String statCd,
+        String marketOk,
+        Long ownUsrId
+) {}
+

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectImageEntity.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectImageEntity.java
@@ -1,0 +1,12 @@
+package com.rbox.object.adapter.out.persistence.repository;
+
+/**
+ * 개체 이미지 정보를 보관하는 엔티티.
+ */
+public record ObjectImageEntity(
+        Long imgId,
+        Long objId,
+        String url,
+        int ordNo
+) {}
+

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectImageRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectImageRepository.java
@@ -1,0 +1,28 @@
+package com.rbox.object.adapter.out.persistence.repository;
+
+import java.util.List;
+
+/**
+ * 개체 이미지 저장소 인터페이스.
+ */
+public interface ObjectImageRepository {
+
+    /**
+     * 개체 이미지 정보를 저장한다.
+     *
+     * @param entity 저장할 이미지
+     * @return 생성된 이미지 ID
+     */
+    Long save(ObjectImageEntity entity);
+
+    /**
+     * 개체 ID로 이미지 목록을 조회한다.
+     */
+    List<ObjectImageEntity> findByObjectId(Long objId);
+
+    /**
+     * 이미지 ID로 이미지를 삭제한다.
+     */
+    void delete(Long imgId);
+}
+

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectRepository.java
@@ -1,0 +1,45 @@
+package com.rbox.object.adapter.out.persistence.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 개체 정보를 저장/조회하기 위한 저장소 인터페이스.
+ */
+public interface ObjectRepository {
+
+    /**
+     * 개체를 저장한다.
+     *
+     * @param entity 저장할 개체
+     * @return 생성된 ID
+     */
+    Long save(ObjectEntity entity);
+
+    /**
+     * ID로 개체를 조회한다.
+     *
+     * @param id 개체 ID
+     * @return 개체 정보
+     */
+    Optional<ObjectEntity> findById(Long id);
+
+    /**
+     * 소유자 ID로 개체 목록을 조회한다.
+     *
+     * @param ownerId 소유자 ID
+     * @return 개체 목록
+     */
+    List<ObjectEntity> findByOwner(Long ownerId);
+
+    /**
+     * 개체 정보를 갱신한다.
+     */
+    void update(ObjectEntity entity);
+
+    /**
+     * 개체를 삭제한다.
+     */
+    void delete(Long id);
+}
+

--- a/src/main/java/com/rbox/object/application/port/in/AddImageCommand.java
+++ b/src/main/java/com/rbox/object/application/port/in/AddImageCommand.java
@@ -1,0 +1,7 @@
+package com.rbox.object.application.port.in;
+
+/**
+ * 이미지 추가 명령.
+ */
+public record AddImageCommand(String url, int ordNo) {}
+

--- a/src/main/java/com/rbox/object/application/port/in/CreateObjectCommand.java
+++ b/src/main/java/com/rbox/object/application/port/in/CreateObjectCommand.java
@@ -1,0 +1,7 @@
+package com.rbox.object.application.port.in;
+
+/**
+ * 개체 생성 명령.
+ */
+public record CreateObjectCommand(String spcCd, String name, String sexCd, String bthYmd) {}
+

--- a/src/main/java/com/rbox/object/application/port/in/ObjectUseCase.java
+++ b/src/main/java/com/rbox/object/application/port/in/ObjectUseCase.java
@@ -1,0 +1,29 @@
+package com.rbox.object.application.port.in;
+
+import java.util.List;
+
+import com.rbox.object.adapter.out.persistence.repository.ObjectEntity;
+import com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity;
+
+/**
+ * 개체 도메인의 UseCase 인터페이스.
+ */
+public interface ObjectUseCase {
+
+    Long createObject(CreateObjectCommand command, Long uid);
+
+    List<ObjectEntity> listObjects(Long uid);
+
+    ObjectEntity getObject(Long id, Long uid);
+
+    void updateObject(Long id, UpdateObjectCommand command, Long uid);
+
+    void deleteObject(Long id, Long uid);
+
+    List<ObjectImageEntity> listImages(Long objId, Long uid);
+
+    Long addImage(Long objId, AddImageCommand command, Long uid);
+
+    void deleteImage(Long objId, Long imgId, Long uid);
+}
+

--- a/src/main/java/com/rbox/object/application/port/in/UpdateObjectCommand.java
+++ b/src/main/java/com/rbox/object/application/port/in/UpdateObjectCommand.java
@@ -1,0 +1,7 @@
+package com.rbox.object.application.port.in;
+
+/**
+ * 개체 수정 명령.
+ */
+public record UpdateObjectCommand(String name, String sexCd, String bthYmd) {}
+

--- a/src/main/java/com/rbox/object/application/service/ObjectService.java
+++ b/src/main/java/com/rbox/object/application/service/ObjectService.java
@@ -1,0 +1,86 @@
+package com.rbox.object.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ErrorCode;
+import com.rbox.common.exception.ApiException;
+import com.rbox.object.adapter.out.persistence.repository.ObjectEntity;
+import com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity;
+import com.rbox.object.adapter.out.persistence.repository.ObjectImageRepository;
+import com.rbox.object.adapter.out.persistence.repository.ObjectRepository;
+import com.rbox.object.application.port.in.AddImageCommand;
+import com.rbox.object.application.port.in.CreateObjectCommand;
+import com.rbox.object.application.port.in.ObjectUseCase;
+import com.rbox.object.application.port.in.UpdateObjectCommand;
+
+/**
+ * 개체 관련 비즈니스 로직을 처리하는 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class ObjectService implements ObjectUseCase {
+    private final ObjectRepository repository;
+    private final ObjectImageRepository imageRepository;
+
+    @Override
+    public Long createObject(CreateObjectCommand command, Long uid) {
+        ObjectEntity entity = new ObjectEntity(null, command.spcCd(), command.name(), command.sexCd(),
+                command.bthYmd(), "SIMPLE", "ACTV", "N", uid);
+        return repository.save(entity);
+    }
+
+    @Override
+    public List<ObjectEntity> listObjects(Long uid) {
+        return repository.findByOwner(uid);
+    }
+
+    @Override
+    public ObjectEntity getObject(Long id, Long uid) {
+        var obj = repository.findById(id).orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "object not found"));
+        if (!uid.equals(obj.ownUsrId())) {
+            throw new ApiException(ErrorCode.FORBIDDEN, "forbidden");
+        }
+        return obj;
+    }
+
+    @Override
+    public void updateObject(Long id, UpdateObjectCommand command, Long uid) {
+        var obj = getObject(id, uid);
+        ObjectEntity updated = new ObjectEntity(obj.id(), obj.spcCd(), command.name(), command.sexCd(),
+                command.bthYmd(), obj.objMode(), obj.statCd(), obj.marketOk(), obj.ownUsrId());
+        repository.update(updated);
+    }
+
+    @Override
+    public void deleteObject(Long id, Long uid) {
+        var obj = getObject(id, uid);
+        repository.delete(obj.id());
+    }
+
+    @Override
+    public List<ObjectImageEntity> listImages(Long objId, Long uid) {
+        getObject(objId, uid); // 소유권 확인
+        return imageRepository.findByObjectId(objId);
+    }
+
+    @Override
+    public Long addImage(Long objId, AddImageCommand command, Long uid) {
+        getObject(objId, uid); // 소유권 확인
+        var images = imageRepository.findByObjectId(objId);
+        if (images.size() >= 10) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "max images exceeded");
+        }
+        return imageRepository.save(new ObjectImageEntity(null, objId, command.url(), command.ordNo()));
+    }
+
+    @Override
+    public void deleteImage(Long objId, Long imgId, Long uid) {
+        getObject(objId, uid); // 소유권 확인
+        imageRepository.delete(imgId);
+    }
+}
+

--- a/src/main/java/com/rbox/system/adapter/in/web/HealthCheckWebCtr.java
+++ b/src/main/java/com/rbox/system/adapter/in/web/HealthCheckWebCtr.java
@@ -9,17 +9,30 @@ import com.rbox.system.application.port.in.HealthCheckUseCase;
 import com.rbox.system.application.port.in.ServerHealthCheckCommand;
 import com.rbox.system.application.port.in.DbHealthCheckCommand;
 
+/**
+ * 시스템 헬스 체크 API를 제공하는 Web Controller.
+ */
 @RestController
 @RequestMapping("/health")
 @RequiredArgsConstructor
 public class HealthCheckWebCtr {
     private final HealthCheckUseCase useCase;
 
+    /**
+     * 서버 상태 확인 API.
+     * <p>입력: 없음</p>
+     * <p>출력: 서버 상태를 나타내는 {@link HealthCheckRes}</p>
+     */
     @GetMapping("/server")
     public HealthCheckRes server(ServerHealthCheckReq req) {
         return useCase.checkServerHealth(new ServerHealthCheckCommand());
     }
 
+    /**
+     * DB 연결 상태 확인 API.
+     * <p>입력: 없음</p>
+     * <p>출력: DB 상태를 나타내는 {@link HealthCheckRes}</p>
+     */
     @GetMapping("/db")
     public HealthCheckRes db(DbHealthCheckReq req) {
         return useCase.checkDbHealth(new DbHealthCheckCommand());

--- a/src/main/java/com/rbox/system/adapter/out/persistence/repository/HealthCheckRepository.java
+++ b/src/main/java/com/rbox/system/adapter/out/persistence/repository/HealthCheckRepository.java
@@ -2,7 +2,15 @@ package com.rbox.system.adapter.out.persistence.repository;
 
 import org.apache.ibatis.annotations.Mapper;
 
+/**
+ * 시스템 DB 헬스 체크를 위한 쿼리를 정의하는 MyBatis Mapper.
+ */
 @Mapper
 public interface HealthCheckRepository {
+    /**
+     * DB 연결을 확인하기 위한 간단한 쿼리.
+     *
+     * @return 항상 1을 반환하여 DB 연결 여부를 확인
+     */
     Integer selectHealth();
 }

--- a/src/main/java/com/rbox/system/application/service/HealthCheckService.java
+++ b/src/main/java/com/rbox/system/application/service/HealthCheckService.java
@@ -10,16 +10,31 @@ import com.rbox.system.application.port.in.ServerHealthCheckCommand;
 import com.rbox.system.application.port.out.DbHealthCheckOutCommand;
 import com.rbox.system.application.port.out.DbHealthCheckPort;
 
+/**
+ * 시스템 헬스 체크 관련 비즈니스 로직을 처리하는 서비스.
+ */
 @Service
 @RequiredArgsConstructor
 public class HealthCheckService implements HealthCheckUseCase {
     private final DbHealthCheckPort dbHealthCheckPort;
 
+    /**
+     * 서버 상태를 확인한다.
+     *
+     * @param command 서버 헬스체크 명령
+     * @return 서버 상태 결과
+     */
     @Override
     public HealthCheckRes checkServerHealth(ServerHealthCheckCommand command) {
         return new HealthCheckRes("OK");
     }
 
+    /**
+     * 데이터베이스 연결 상태를 확인한다.
+     *
+     * @param command DB 헬스체크 명령
+     * @return DB 상태 결과
+     */
     @Override
     public HealthCheckRes checkDbHealth(DbHealthCheckCommand command) {
         boolean ok = dbHealthCheckPort.check(new DbHealthCheckOutCommand());

--- a/src/main/java/com/rbox/user/adapter/in/web/UserWebCtr.java
+++ b/src/main/java/com/rbox/user/adapter/in/web/UserWebCtr.java
@@ -10,12 +10,20 @@ import com.rbox.common.api.ApiResponse;
 import com.rbox.user.application.port.in.UserMe;
 import com.rbox.user.application.port.in.UserUseCase;
 
+/**
+ * 사용자 관련 API를 제공하는 Web Controller.
+ */
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserWebCtr {
     private final UserUseCase useCase;
 
+    /**
+     * 내 정보 조회 API.
+     * <p>입력: 없음(인증 정보 이용)</p>
+     * <p>출력: 사용자 기본 정보 {@link UserMe}</p>
+     */
     @GetMapping("/me")
     public ApiResponse<UserMe> me() {
         return ApiResponse.success(useCase.getMe(1L));

--- a/src/main/java/com/rbox/user/adapter/out/persistence/repository/UserRepository.java
+++ b/src/main/java/com/rbox/user/adapter/out/persistence/repository/UserRepository.java
@@ -3,8 +3,24 @@ package com.rbox.user.adapter.out.persistence.repository;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+/**
+ * 사용자 정보를 조회하기 위한 MyBatis Mapper.
+ */
 @Mapper
 public interface UserRepository {
+    /**
+     * 이메일로 사용자 정보를 조회한다.
+     *
+     * @param email 사용자 이메일
+     * @return 사용자 엔티티
+     */
     UserEntity findByEmail(@Param("email") String email);
+
+    /**
+     * ID로 사용자 정보를 조회한다.
+     *
+     * @param id 사용자 ID
+     * @return 사용자 엔티티
+     */
     UserEntity findById(@Param("id") Long id);
 }

--- a/src/main/java/com/rbox/user/application/service/UserService.java
+++ b/src/main/java/com/rbox/user/application/service/UserService.java
@@ -9,11 +9,20 @@ import com.rbox.user.adapter.out.persistence.repository.UserRepository;
 import com.rbox.user.application.port.in.UserMe;
 import com.rbox.user.application.port.in.UserUseCase;
 
+/**
+ * 사용자 관련 비즈니스 로직을 처리하는 서비스.
+ */
 @Service
 @RequiredArgsConstructor
 public class UserService implements UserUseCase {
     private final UserRepository repository;
 
+    /**
+     * 로그인한 사용자의 정보를 조회한다.
+     *
+     * @param uid 사용자 ID
+     * @return 사용자 기본 정보
+     */
     @Override
     public UserMe getMe(Long uid) {
         var user = repository.findById(uid);

--- a/src/main/resources/mybatis/system/HealthCheckRepository.xml
+++ b/src/main/resources/mybatis/system/HealthCheckRepository.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.rbox.system.adapter.out.persistence.repository.HealthCheckRepository">
+  <!-- DB 연결 상태를 확인하기 위한 단순 쿼리 -->
   <select id="selectHealth" resultType="int">
     SELECT 1
   </select>

--- a/src/main/resources/mybatis/user/UserRepository.xml
+++ b/src/main/resources/mybatis/user/UserRepository.xml
@@ -9,12 +9,14 @@
     <result property="password" column="pwd" />
   </resultMap>
 
+  <!-- 이메일로 사용자 조회 -->
   <select id="findByEmail" parameterType="string" resultMap="UserMap">
     SELECT usr_id, email, nick, stat_cd, pwd
     FROM tb_usr
     WHERE email = #{email}
   </select>
 
+  <!-- ID로 사용자 조회 -->
   <select id="findById" parameterType="long" resultMap="UserMap">
     SELECT usr_id, email, nick, stat_cd, pwd
     FROM tb_usr


### PR DESCRIPTION
## Summary
- document existing controllers, services, repositories, and MyBatis queries with clear API descriptions
- implement simple in-memory object CRUD and image APIs

## Testing
- `gradle test` *(fails: Could not resolve org.projectlombok:lombok:1.18.30 - status code 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68be3e0e76b8832ebc229ce39c903371