### PR TITLE
feat: add stub endpoints for notifications and dashboard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/rbox/dashboard/adapter/in/web/DashboardWebCtr.java
+++ b/src/main/java/com/rbox/dashboard/adapter/in/web/DashboardWebCtr.java
@@ -1,0 +1,57 @@
+package com.rbox.dashboard.adapter.in.web;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.rbox.common.api.ApiResponse;
+
+/**
+ * 사용자 대시보드 요약 API.
+ */
+@RestController
+@RequestMapping("/dashboard")
+public class DashboardWebCtr {
+
+    /**
+     * 오늘/이번주 처리해야 할 브리딩 작업 요약을 반환한다.
+     */
+    @GetMapping("/overview")
+    public ApiResponse<Map<String, Object>> overview() {
+        // TODO 실제 데이터 연동 필요
+        Map<String, Integer> today = Map.of(
+                "layEtd", 1,
+                "layChk", 2,
+                "hatEtd", 1
+        );
+
+        Map<String, Integer> week = Map.of(
+                "layEtd", 2,
+                "layChk", 3,
+                "hatEtd", 2
+        );
+
+        List<Map<String, Object>> highlights = List.of(
+                Map.of(
+                        "type", "LAY_CHK",
+                        "title", "산란 확인 필요",
+                        "femObjId", 101L,
+                        "cltId", 7001L,
+                        "due", LocalDate.now().toString()
+                )
+        );
+
+        Map<String, Object> data = Map.of(
+                "today", today,
+                "week", week,
+                "highlights", highlights
+        );
+
+        return ApiResponse.success(data);
+    }
+}
+

--- a/src/main/java/com/rbox/notification/adapter/in/web/NotificationWebCtr.java
+++ b/src/main/java/com/rbox/notification/adapter/in/web/NotificationWebCtr.java
@@ -1,0 +1,55 @@
+package com.rbox.notification.adapter.in.web;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.rbox.common.api.ApiResponse;
+
+/**
+ * 브리딩 관련 알림 요약 API.
+ */
+@RestController
+@RequestMapping("/notifications")
+public class NotificationWebCtr {
+
+    /**
+     * 로그인 사용자의 다가오는 알림 목록을 조회한다.
+     *
+     * @param type 알림 종류 필터 (옵션)
+     * @return 알림 목록 및 페이지 정보
+     */
+    @GetMapping("/upcoming")
+    public ApiResponse<List<Map<String, Object>>> upcoming(
+            @RequestParam(name = "type", required = false) String type) {
+        // TODO 실제 구현에서는 서비스/리포지토리 연동 필요
+        List<Map<String, Object>> data = List.of(
+                Map.of(
+                        "type", "LAY_ETD",
+                        "dueDt", LocalDateTime.now().plusDays(1).toString(),
+                        "ref", Map.of("pairingId", 5001L, "femObjId", 101L, "malObjId", 202L),
+                        "message", "암컷 #101 산란 예정"
+                ),
+                Map.of(
+                        "type", "HAT_ETD",
+                        "dueDt", LocalDateTime.now().plusDays(5).toString(),
+                        "ref", Map.of("eggId", 73005L, "cltId", 7001L, "femObjId", 101L),
+                        "message", "클러치 #7001 알 #5 해칭 예정"
+                )
+        );
+
+        Map<String, Object> meta = Map.of(
+                "page", 1,
+                "size", data.size(),
+                "total", data.size()
+        );
+
+        return new ApiResponse<>(data, meta, null);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add placeholder `/notifications/upcoming` API returning sample notifications
- add placeholder `/dashboard/overview` API showing today and week counts
- include validation starter dependency

## Testing
- `gradle test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-validation 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be58ca3f40832eab7bb097f67baa19