### PR TITLE
Add lineage and snapshot APIs with in-memory implementation

### DIFF
--- a/src/main/java/com/rbox/lineage/adapter/in/web/LineageWebCtr.java
+++ b/src/main/java/com/rbox/lineage/adapter/in/web/LineageWebCtr.java
@@ -1,0 +1,30 @@
+package com.rbox.lineage.adapter.in.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+import com.rbox.lineage.application.port.in.LineageGraph;
+import com.rbox.lineage.application.port.in.LineageUseCase;
+
+/**
+ * 계보 조회 API 컨트롤러.
+ */
+@RestController
+@RequestMapping("/lineage")
+@RequiredArgsConstructor
+public class LineageWebCtr {
+    private final LineageUseCase useCase;
+
+    @GetMapping("/{id}/ancestors")
+    public ApiResponse<LineageGraph> ancestors(@PathVariable Long id,
+            @RequestParam(name = "depth", defaultValue = "3") int depth) {
+        // 데모용으로 uid=1 고정
+        return ApiResponse.success(useCase.getAncestors(1L, id, depth));
+    }
+}

--- a/src/main/java/com/rbox/lineage/application/port/in/LineageEdge.java
+++ b/src/main/java/com/rbox/lineage/application/port/in/LineageEdge.java
@@ -1,0 +1,6 @@
+package com.rbox.lineage.application.port.in;
+
+/**
+ * 계보 간선(from->to 관계) 정보를 표현한다.
+ */
+public record LineageEdge(Long from, Long to, String rel) {}

--- a/src/main/java/com/rbox/lineage/application/port/in/LineageGraph.java
+++ b/src/main/java/com/rbox/lineage/application/port/in/LineageGraph.java
@@ -1,0 +1,9 @@
+package com.rbox.lineage.application.port.in;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 계보 그래프 응답 데이터.
+ */
+public record LineageGraph(Long root, int depth, List<LineageNode> nodes, List<LineageEdge> edges, Map<String, Object> meta) {}

--- a/src/main/java/com/rbox/lineage/application/port/in/LineageNode.java
+++ b/src/main/java/com/rbox/lineage/application/port/in/LineageNode.java
@@ -1,0 +1,6 @@
+package com.rbox.lineage.application.port.in;
+
+/**
+ * 계보 노드 정보를 표현한다.
+ */
+public record LineageNode(Long id, String name, String sexCd, String spcCd, String bthYmd) {}

--- a/src/main/java/com/rbox/lineage/application/port/in/LineageUseCase.java
+++ b/src/main/java/com/rbox/lineage/application/port/in/LineageUseCase.java
@@ -1,0 +1,16 @@
+package com.rbox.lineage.application.port.in;
+
+/**
+ * 계보 조회용 유스케이스.
+ */
+public interface LineageUseCase {
+    /**
+     * 주어진 개체의 조상 계보를 조회한다.
+     * 
+     * @param uid    로그인 사용자 ID
+     * @param rootId 루트 개체 ID
+     * @param depth  조회 깊이(1~3)
+     * @return 계보 그래프
+     */
+    LineageGraph getAncestors(Long uid, Long rootId, int depth);
+}

--- a/src/main/java/com/rbox/lineage/application/service/LineageService.java
+++ b/src/main/java/com/rbox/lineage/application/service/LineageService.java
@@ -1,0 +1,106 @@
+package com.rbox.lineage.application.service;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import org.springframework.stereotype.Service;
+
+import com.rbox.common.api.ErrorCode;
+import com.rbox.common.exception.ApiException;
+import com.rbox.lineage.application.port.in.LineageEdge;
+import com.rbox.lineage.application.port.in.LineageGraph;
+import com.rbox.lineage.application.port.in.LineageNode;
+import com.rbox.lineage.application.port.in.LineageUseCase;
+
+/**
+ * 간단한 메모리 기반 계보 조회 서비스 구현.
+ */
+@Service
+public class LineageService implements LineageUseCase {
+
+    /** 동물 정보 저장소 (데모용). */
+    private final Map<Long, Animal> store = new HashMap<>();
+
+    public LineageService() {
+        // 3세대 계보 샘플 데이터 구성
+        store.put(123L, new Animal(123L, "Alpha", "F", "GECKO", "2025-08-20", 90L, 91L, 1L));
+        store.put(90L, new Animal(90L, "Sire", "M", null, null, 80L, 81L, 0L));
+        store.put(91L, new Animal(91L, "Dam", "F", null, null, 82L, 83L, 0L));
+        store.put(80L, new Animal(80L, "GF1", "M", null, null, 70L, 71L, 0L));
+        store.put(81L, new Animal(81L, "GM1", "F", null, null, 72L, 73L, 0L));
+        store.put(82L, new Animal(82L, "GF2", "M", null, null, 74L, 75L, 0L));
+        store.put(83L, new Animal(83L, "GM2", "F", null, null, 76L, 77L, 0L));
+        store.put(70L, new Animal(70L, "GGF1", "M", null, null, null, null, 0L));
+        store.put(71L, new Animal(71L, "GGM1", "F", null, null, null, null, 0L));
+        store.put(72L, new Animal(72L, "GGF2", "M", null, null, null, null, 0L));
+        store.put(73L, new Animal(73L, "GGM2", "F", null, null, null, null, 0L));
+        store.put(74L, new Animal(74L, "GGF3", "M", null, null, null, null, 0L));
+        store.put(75L, new Animal(75L, "GGM3", "F", null, null, null, null, 0L));
+        store.put(76L, new Animal(76L, "GGF4", "M", null, null, null, null, 0L));
+        store.put(77L, new Animal(77L, "GGM4", "F", null, null, null, null, 0L));
+    }
+
+    @Override
+    public LineageGraph getAncestors(Long uid, Long rootId, int depth) {
+        if (depth < 1 || depth > 3) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "depth must be 1..3");
+        }
+        Animal root = store.get(rootId);
+        if (root == null) {
+            throw new ApiException(ErrorCode.NOT_FOUND, "object not found");
+        }
+        if (!uid.equals(root.ownUsrId())) {
+            throw new ApiException(ErrorCode.FORBIDDEN, "forbidden");
+        }
+
+        List<LineageNode> nodes = new ArrayList<>();
+        List<LineageEdge> edges = new ArrayList<>();
+        Map<Long, Boolean> visited = new HashMap<>();
+        Queue<Gen> q = new ArrayDeque<>();
+        q.add(new Gen(root, 0));
+        visited.put(root.id(), true);
+
+        while (!q.isEmpty()) {
+            Gen cur = q.poll();
+            Animal a = cur.animal();
+            nodes.add(new LineageNode(a.id(), a.name(), a.sexCd(), a.spcCd(), a.bthYmd()));
+            if (cur.gen() >= depth) {
+                continue;
+            }
+            if (a.faId() != null) {
+                Animal fa = store.get(a.faId());
+                if (fa != null) {
+                    if (visited.putIfAbsent(fa.id(), true) == null) {
+                        q.add(new Gen(fa, cur.gen() + 1));
+                    }
+                    edges.add(new LineageEdge(fa.id(), a.id(), "FA"));
+                }
+            }
+            if (a.moId() != null) {
+                Animal mo = store.get(a.moId());
+                if (mo != null) {
+                    if (visited.putIfAbsent(mo.id(), true) == null) {
+                        q.add(new Gen(mo, cur.gen() + 1));
+                    }
+                    edges.add(new LineageEdge(mo.id(), a.id(), "MO"));
+                }
+            }
+        }
+
+        Map<String, Object> meta = Map.of("generatedAt", ZonedDateTime.now().toString());
+        return new LineageGraph(rootId, depth, nodes, edges, meta);
+    }
+
+    /** 내부적으로 사용하는 동물 정보. */
+    private record Animal(Long id, String name, String sexCd, String spcCd, String bthYmd, Long faId, Long moId,
+            Long ownUsrId) {
+    }
+
+    private record Gen(Animal animal, int gen) {
+    }
+}

--- a/src/main/java/com/rbox/snapshot/adapter/in/web/SnapshotCreateReq.java
+++ b/src/main/java/com/rbox/snapshot/adapter/in/web/SnapshotCreateReq.java
@@ -1,0 +1,14 @@
+package com.rbox.snapshot.adapter.in.web;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 스냅샷 생성 요청.
+ */
+public record SnapshotCreateReq(
+        @NotNull Long rootObjId,
+        @Min(1) @Max(365) Integer ttlDays,
+        String note
+) {}

--- a/src/main/java/com/rbox/snapshot/adapter/in/web/SnapshotWebCtr.java
+++ b/src/main/java/com/rbox/snapshot/adapter/in/web/SnapshotWebCtr.java
@@ -1,0 +1,41 @@
+package com.rbox.snapshot.adapter.in.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+import com.rbox.lineage.application.port.in.LineageGraph;
+import com.rbox.snapshot.application.port.in.SnapshotCreateCommand;
+import com.rbox.snapshot.application.port.in.SnapshotCreateResp;
+import com.rbox.snapshot.application.port.in.SnapshotUseCase;
+
+/**
+ * 3세대 계보 스냅샷 API.
+ */
+@RestController
+@RequestMapping("/snapshots/3gen")
+@RequiredArgsConstructor
+public class SnapshotWebCtr {
+    private final SnapshotUseCase useCase;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<SnapshotCreateResp>> create(@Valid @RequestBody SnapshotCreateReq req) {
+        SnapshotCreateResp resp = useCase.createSnapshot(
+                new SnapshotCreateCommand(req.rootObjId(), req.ttlDays(), req.note()), 1L);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(resp));
+    }
+
+    @GetMapping("/{token}")
+    public ApiResponse<LineageGraph> get(@PathVariable String token) {
+        return ApiResponse.success(useCase.getSnapshot(token));
+    }
+}

--- a/src/main/java/com/rbox/snapshot/application/port/in/SnapshotCreateCommand.java
+++ b/src/main/java/com/rbox/snapshot/application/port/in/SnapshotCreateCommand.java
@@ -1,0 +1,6 @@
+package com.rbox.snapshot.application.port.in;
+
+/**
+ * 스냅샷 생성 입력 커맨드.
+ */
+public record SnapshotCreateCommand(Long rootObjId, Integer ttlDays, String note) {}

--- a/src/main/java/com/rbox/snapshot/application/port/in/SnapshotCreateResp.java
+++ b/src/main/java/com/rbox/snapshot/application/port/in/SnapshotCreateResp.java
@@ -1,0 +1,8 @@
+package com.rbox.snapshot.application.port.in;
+
+import java.time.ZonedDateTime;
+
+/**
+ * 스냅샷 생성 결과.
+ */
+public record SnapshotCreateResp(Long snapId, String shareToken, ZonedDateTime expireAt, Long rootObjId) {}

--- a/src/main/java/com/rbox/snapshot/application/port/in/SnapshotUseCase.java
+++ b/src/main/java/com/rbox/snapshot/application/port/in/SnapshotUseCase.java
@@ -1,0 +1,19 @@
+package com.rbox.snapshot.application.port.in;
+
+import com.rbox.lineage.application.port.in.LineageGraph;
+
+/**
+ * 3세대 계보 스냅샷 관련 유스케이스.
+ */
+public interface SnapshotUseCase {
+
+    /**
+     * 스냅샷을 생성한다.
+     */
+    SnapshotCreateResp createSnapshot(SnapshotCreateCommand cmd, Long uid);
+
+    /**
+     * 토큰으로 스냅샷을 조회한다.
+     */
+    LineageGraph getSnapshot(String token);
+}

--- a/src/main/java/com/rbox/snapshot/application/service/SnapshotService.java
+++ b/src/main/java/com/rbox/snapshot/application/service/SnapshotService.java
@@ -1,0 +1,82 @@
+package com.rbox.snapshot.application.service;
+
+import java.security.SecureRandom;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ErrorCode;
+import com.rbox.common.exception.ApiException;
+import com.rbox.lineage.application.port.in.LineageGraph;
+import com.rbox.lineage.application.port.in.LineageUseCase;
+import com.rbox.snapshot.application.port.in.SnapshotCreateCommand;
+import com.rbox.snapshot.application.port.in.SnapshotCreateResp;
+import com.rbox.snapshot.application.port.in.SnapshotUseCase;
+
+/**
+ * 간단한 메모리 기반 스냅샷 서비스 구현.
+ */
+@Service
+@RequiredArgsConstructor
+public class SnapshotService implements SnapshotUseCase {
+    private final LineageUseCase lineageUseCase;
+
+    private final Map<String, Snapshot> store = new ConcurrentHashMap<>();
+    private final AtomicLong seq = new AtomicLong(1);
+    private final SecureRandom random = new SecureRandom();
+
+    @Override
+    public SnapshotCreateResp createSnapshot(SnapshotCreateCommand cmd, Long uid) {
+        int ttl = cmd.ttlDays() == null ? 30 : cmd.ttlDays();
+        if (ttl < 1 || ttl > 365) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "ttlDays must be 1..365");
+        }
+        LineageGraph graph = lineageUseCase.getAncestors(uid, cmd.rootObjId(), 3);
+        String token;
+        do {
+            token = generateToken();
+        } while (store.containsKey(token));
+        long id = seq.getAndIncrement();
+        ZonedDateTime exp = ZonedDateTime.now().plusDays(ttl);
+        store.put(token, new Snapshot(id, cmd.rootObjId(), graph, exp));
+        return new SnapshotCreateResp(id, token, exp, cmd.rootObjId());
+    }
+
+    @Override
+    public LineageGraph getSnapshot(String token) {
+        Snapshot snap = store.get(token);
+        if (snap == null || (snap.expireAt != null && snap.expireAt.isBefore(ZonedDateTime.now()))) {
+            throw new ApiException(ErrorCode.NOT_FOUND, "snapshot not found");
+        }
+        return snap.payload;
+    }
+
+    private String generateToken() {
+        byte[] buf = new byte[16];
+        random.nextBytes(buf);
+        StringBuilder sb = new StringBuilder();
+        for (byte b : buf) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    private static class Snapshot {
+        final long id;
+        final long rootObjId;
+        final LineageGraph payload;
+        final ZonedDateTime expireAt;
+
+        Snapshot(long id, long rootObjId, LineageGraph payload, ZonedDateTime expireAt) {
+            this.id = id;
+            this.rootObjId = rootObjId;
+            this.payload = payload;
+            this.expireAt = expireAt;
+        }
+    }
+}

--- a/src/test/java/com/rbox/lineage/LineageServiceTest.java
+++ b/src/test/java/com/rbox/lineage/LineageServiceTest.java
@@ -1,0 +1,39 @@
+package com.rbox.lineage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.rbox.lineage.application.port.in.LineageGraph;
+import com.rbox.lineage.application.service.LineageService;
+
+class LineageServiceTest {
+    private LineageService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LineageService();
+    }
+
+    @Test
+    void depth3ShouldReturn15Nodes() {
+        LineageGraph g = service.getAncestors(1L, 123L, 3);
+        assertEquals(15, g.nodes().size());
+        assertEquals(14, g.edges().size());
+    }
+
+    @Test
+    void depth2ShouldReturn7Nodes() {
+        LineageGraph g = service.getAncestors(1L, 123L, 2);
+        assertEquals(7, g.nodes().size());
+        assertEquals(6, g.edges().size());
+    }
+
+    @Test
+    void depth1ShouldReturn3Nodes() {
+        LineageGraph g = service.getAncestors(1L, 123L, 1);
+        assertEquals(3, g.nodes().size());
+        assertEquals(2, g.edges().size());
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory lineage service to compute up to three generations
- provide lineage and snapshot REST endpoints with shareable tokens
- store snapshots in memory with TTL support and basic unit tests

## Testing
- `gradle test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-validation:3.2.2 - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be59f08760832e9159fb726eaed637