### PR TITLE
feat: add auction and bidding APIs

### DIFF
--- a/src/main/java/com/rbox/RboxApiApplication.java
+++ b/src/main/java/com/rbox/RboxApiApplication.java
@@ -2,8 +2,10 @@ package com.rbox;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class RboxApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/rbox/market/auction/Auction.java
+++ b/src/main/java/com/rbox/market/auction/Auction.java
@@ -1,0 +1,54 @@
+package com.rbox.market.auction;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simplified in-memory Auction entity.
+ */
+public class Auction {
+    public enum Status { ACTV, DONE, CANC }
+
+    private Long id;
+    private Long objId;
+    private Long ownerId;
+    private String currency;
+    private long minBid;
+    private long incStep;
+    private Instant startAt;
+    private Instant endAt;
+    private Status status = Status.ACTV;
+
+    private List<Bid> bids = new ArrayList<>();
+
+    public Auction(Long id, Long objId, Long ownerId, String currency, long minBid, long incStep,
+                   Instant startAt, Instant endAt) {
+        this.id = id;
+        this.objId = objId;
+        this.ownerId = ownerId;
+        this.currency = currency;
+        this.minBid = minBid;
+        this.incStep = incStep;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    public Long getId() { return id; }
+    public Long getObjId() { return objId; }
+    public Long getOwnerId() { return ownerId; }
+    public String getCurrency() { return currency; }
+    public long getMinBid() { return minBid; }
+    public long getIncStep() { return incStep; }
+    public Instant getStartAt() { return startAt; }
+    public Instant getEndAt() { return endAt; }
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+
+    public List<Bid> getBids() { return bids; }
+    public Bid getHighestBid() {
+        return bids.stream().max((a,b) -> Long.compare(a.getAmount(), b.getAmount())).orElse(null);
+    }
+
+    public void addBid(Bid b) { bids.add(b); }
+}

--- a/src/main/java/com/rbox/market/auction/AuctionController.java
+++ b/src/main/java/com/rbox/market/auction/AuctionController.java
@@ -1,0 +1,78 @@
+package com.rbox.market.auction;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller exposing minimal auction APIs based on the spec.
+ */
+@RestController
+@RequestMapping("/market/auctions")
+public class AuctionController {
+    private final AuctionService service;
+    private final Clock clock;
+
+    public AuctionController(AuctionService service, Clock clock) {
+        this.service = service;
+        this.clock = clock;
+    }
+
+    private Long getUserId(String header) {
+        if (header == null) return null;
+        return Long.valueOf(header);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public IdResponse create(@RequestHeader("X-USER-ID") String user,
+                             @RequestBody AuctionCreateRequest req) {
+        Auction auc = service.create(getUserId(user), req);
+        return new IdResponse(auc.getId());
+    }
+
+    @GetMapping
+    public List<Auction> list() {
+        return service.list();
+    }
+
+    @GetMapping("/{id}")
+    public Auction get(@PathVariable Long id) {
+        Auction auc = service.get(id);
+        if (auc == null) throw new ResourceNotFound();
+        return auc;
+    }
+
+    @PostMapping("/{id}/bids")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Bid placeBid(@RequestHeader("X-USER-ID") String user,
+                        @PathVariable Long id, @RequestBody BidRequest req) {
+        return service.placeBid(id, getUserId(user), req.amount());
+    }
+
+    @GetMapping("/{id}/winner")
+    public AuctionWinner winner(@PathVariable Long id) {
+        AuctionWinner w = service.getWinner(id);
+        if (w == null) throw new ResourceNotFound();
+        return w;
+    }
+
+    @PostMapping("/{id}/winner/pay")
+    public void pay(@PathVariable Long id, @RequestBody PayRequest req) {
+        Instant paidAt = req.paidAt() != null ? req.paidAt() : clock.instant();
+        service.markPaid(id, paidAt, req.txId());
+    }
+
+    @PostMapping("/{id}/winner/cancel")
+    public void cancel(@PathVariable Long id, @RequestBody CancelRequest req) {
+        service.cancel(id, req.reason());
+    }
+
+    record IdResponse(Long id) {}
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    static class ResourceNotFound extends RuntimeException {}
+}

--- a/src/main/java/com/rbox/market/auction/AuctionCreateRequest.java
+++ b/src/main/java/com/rbox/market/auction/AuctionCreateRequest.java
@@ -1,0 +1,8 @@
+package com.rbox.market.auction;
+
+import java.time.Instant;
+
+/** Request object for creating auction */
+public record AuctionCreateRequest(Long objId, String curCd, long minBid, long incStep,
+        Instant startAt, Instant endAt, boolean profileOnly) {
+}

--- a/src/main/java/com/rbox/market/auction/AuctionService.java
+++ b/src/main/java/com/rbox/market/auction/AuctionService.java
@@ -1,0 +1,109 @@
+package com.rbox.market.auction;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * In-memory auction service implementing basic rules from spec.
+ */
+@Service
+public class AuctionService {
+    private final Map<Long, Auction> auctions = new ConcurrentHashMap<>();
+    private final Map<Long, AuctionWinner> winners = new ConcurrentHashMap<>();
+    private final Clock clock;
+    private long seq = 1000;
+
+    public AuctionService(Clock clock) {
+        this.clock = clock;
+    }
+
+    public synchronized Auction create(Long ownerId, AuctionCreateRequest req) {
+        if (req.startAt().isAfter(req.endAt())) {
+            throw new IllegalArgumentException("startAt must be before endAt");
+        }
+        if (req.minBid() <= 0 || req.incStep() <= 0) {
+            throw new IllegalArgumentException("bid values must be >0");
+        }
+        Auction auc = new Auction(++seq, req.objId(), ownerId, req.curCd(), req.minBid(),
+                req.incStep(), req.startAt(), req.endAt());
+        auctions.put(auc.getId(), auc);
+        return auc;
+    }
+
+    public List<Auction> list() {
+        return new ArrayList<>(auctions.values());
+    }
+
+    public Auction get(Long id) {
+        return auctions.get(id);
+    }
+
+    public synchronized Bid placeBid(Long auctionId, Long userId, long amount) {
+        Auction auc = auctions.get(auctionId);
+        if (auc == null) throw new IllegalArgumentException("auction not found");
+        Instant now = clock.instant();
+        if (auc.getStatus() != Auction.Status.ACTV)
+            throw new IllegalStateException("auction not active");
+        if (now.isBefore(auc.getStartAt()) || now.isAfter(auc.getEndAt()))
+            throw new IllegalStateException("auction not in time window");
+        Bid current = auc.getHighestBid();
+        long minRequired = current == null ? auc.getMinBid() : current.getAmount() + auc.getIncStep();
+        if (amount < minRequired) {
+            throw new IllegalArgumentException("bid too low");
+        }
+        Bid bid = new Bid(userId, amount, now);
+        auc.addBid(bid);
+        return bid;
+    }
+
+    public AuctionWinner getWinner(Long auctionId) {
+        Auction auc = auctions.get(auctionId);
+        if (auc == null) return null;
+        finalizeAuctionIfNeeded(auc);
+        return winners.get(auctionId);
+    }
+
+    private void finalizeAuctionIfNeeded(Auction auc) {
+        if (auc.getStatus() == Auction.Status.DONE) return;
+        Instant now = clock.instant();
+        if (now.isBefore(auc.getEndAt())) return; // not yet ended
+        Bid highest = auc.getBids().stream().max(Comparator.comparingLong(Bid::getAmount)).orElse(null);
+        auc.setStatus(Auction.Status.DONE);
+        if (highest != null) {
+            Instant payDue = now.plus(24, ChronoUnit.HOURS); // simple fixed TTL
+            winners.put(auc.getId(), new AuctionWinner(auc.getId(), highest.getUserId(), highest.getAmount(), payDue));
+        }
+    }
+
+    public void markPaid(Long auctionId, Instant paidAt, String txId) {
+        AuctionWinner w = winners.get(auctionId);
+        if (w == null) throw new IllegalArgumentException("no winner");
+        if (w.getPayStatus() != AuctionWinner.PayStatus.WAIT)
+            throw new IllegalStateException("cannot pay in current state");
+        w.setPayStatus(AuctionWinner.PayStatus.PAID);
+        w.setPaidAt(paidAt);
+        w.setTxId(txId);
+    }
+
+    public void cancel(Long auctionId, String reason) {
+        AuctionWinner w = winners.get(auctionId);
+        if (w == null) throw new IllegalArgumentException("no winner");
+        w.setPayStatus(AuctionWinner.PayStatus.CANCEL);
+    }
+
+    /** called by scheduled job to expire payment */
+    public void expirePayments() {
+        Instant now = clock.instant();
+        winners.values().stream()
+            .filter(w -> w.getPayStatus() == AuctionWinner.PayStatus.WAIT && now.isAfter(w.getPayDue()))
+            .forEach(w -> w.setPayStatus(AuctionWinner.PayStatus.EXPIRE));
+    }
+}

--- a/src/main/java/com/rbox/market/auction/AuctionWinner.java
+++ b/src/main/java/com/rbox/market/auction/AuctionWinner.java
@@ -1,0 +1,34 @@
+package com.rbox.market.auction;
+
+import java.time.Instant;
+
+/** Winner information once auction ends. */
+public class AuctionWinner {
+    public enum PayStatus { WAIT, PAID, EXPIRE, CANCEL }
+
+    private final Long auctionId;
+    private final Long userId;
+    private final long amount;
+    private PayStatus payStatus = PayStatus.WAIT;
+    private final Instant payDue;
+    private Instant paidAt;
+    private String txId;
+
+    public AuctionWinner(Long auctionId, Long userId, long amount, Instant payDue) {
+        this.auctionId = auctionId;
+        this.userId = userId;
+        this.amount = amount;
+        this.payDue = payDue;
+    }
+
+    public Long getAuctionId() { return auctionId; }
+    public Long getUserId() { return userId; }
+    public long getAmount() { return amount; }
+    public PayStatus getPayStatus() { return payStatus; }
+    public void setPayStatus(PayStatus payStatus) { this.payStatus = payStatus; }
+    public Instant getPayDue() { return payDue; }
+    public Instant getPaidAt() { return paidAt; }
+    public void setPaidAt(Instant paidAt) { this.paidAt = paidAt; }
+    public String getTxId() { return txId; }
+    public void setTxId(String txId) { this.txId = txId; }
+}

--- a/src/main/java/com/rbox/market/auction/Bid.java
+++ b/src/main/java/com/rbox/market/auction/Bid.java
@@ -1,0 +1,20 @@
+package com.rbox.market.auction;
+
+import java.time.Instant;
+
+/** Simple bid record. */
+public class Bid {
+    private final Long userId;
+    private final long amount;
+    private final Instant bidAt;
+
+    public Bid(Long userId, long amount, Instant bidAt) {
+        this.userId = userId;
+        this.amount = amount;
+        this.bidAt = bidAt;
+    }
+
+    public Long getUserId() { return userId; }
+    public long getAmount() { return amount; }
+    public Instant getBidAt() { return bidAt; }
+}

--- a/src/main/java/com/rbox/market/auction/BidRequest.java
+++ b/src/main/java/com/rbox/market/auction/BidRequest.java
@@ -1,0 +1,4 @@
+package com.rbox.market.auction;
+
+/** Request body for placing bid */
+public record BidRequest(long amount) {}

--- a/src/main/java/com/rbox/market/auction/CancelRequest.java
+++ b/src/main/java/com/rbox/market/auction/CancelRequest.java
@@ -1,0 +1,4 @@
+package com.rbox.market.auction;
+
+/** Request for canceling winner */
+public record CancelRequest(String reason) {}

--- a/src/main/java/com/rbox/market/auction/ClockConfig.java
+++ b/src/main/java/com/rbox/market/auction/ClockConfig.java
@@ -1,0 +1,14 @@
+package com.rbox.market.auction;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/com/rbox/market/auction/PayRequest.java
+++ b/src/main/java/com/rbox/market/auction/PayRequest.java
@@ -1,0 +1,6 @@
+package com.rbox.market.auction;
+
+import java.time.Instant;
+
+/** Request for marking payment */
+public record PayRequest(Instant paidAt, String txId) {}

--- a/src/main/java/com/rbox/market/auction/PaymentExpiryJob.java
+++ b/src/main/java/com/rbox/market/auction/PaymentExpiryJob.java
@@ -1,0 +1,19 @@
+package com.rbox.market.auction;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Job that marks WAIT winners as EXPIRE after payDue. */
+@Component
+public class PaymentExpiryJob {
+    private final AuctionService service;
+
+    public PaymentExpiryJob(AuctionService service) {
+        this.service = service;
+    }
+
+    @Scheduled(fixedDelay = 600_000) // every 10 minutes
+    public void run() {
+        service.expirePayments();
+    }
+}

--- a/src/test/java/com/rbox/market/auction/AuctionServiceTest.java
+++ b/src/test/java/com/rbox/market/auction/AuctionServiceTest.java
@@ -1,0 +1,57 @@
+package com.rbox.market.auction;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AuctionServiceTest {
+    static class MutableClock extends Clock {
+        private Instant instant;
+        MutableClock(Instant i) { this.instant = i; }
+        void set(Instant i) { this.instant = i; }
+        @Override public ZoneId getZone() { return ZoneId.of("UTC"); }
+        @Override public Clock withZone(ZoneId zone) { return this; }
+        @Override public Instant instant() { return instant; }
+    }
+
+    private MutableClock clock;
+    private AuctionService service;
+
+    @BeforeEach
+    void setup() {
+        clock = new MutableClock(Instant.parse("2025-10-01T00:00:00Z"));
+        service = new AuctionService(clock);
+    }
+
+    @Test
+    void createBidWinnerAndPay() {
+        AuctionCreateRequest req = new AuctionCreateRequest(1001L, "KRW", 100, 10,
+                Instant.parse("2025-10-01T00:00:00Z"), Instant.parse("2025-10-01T12:00:00Z"), false);
+        Auction auc = service.create(1L, req);
+        service.placeBid(auc.getId(), 2L, 100);
+        clock.set(Instant.parse("2025-10-02T00:00:00Z"));
+        AuctionWinner w = service.getWinner(auc.getId());
+        assertNotNull(w);
+        assertEquals(AuctionWinner.PayStatus.WAIT, w.getPayStatus());
+        service.markPaid(auc.getId(), clock.instant(), "TX1");
+        assertEquals(AuctionWinner.PayStatus.PAID, w.getPayStatus());
+    }
+
+    @Test
+    void expirePayment() {
+        AuctionCreateRequest req = new AuctionCreateRequest(1001L, "KRW", 100, 10,
+                Instant.parse("2025-10-01T00:00:00Z"), Instant.parse("2025-10-01T12:00:00Z"), false);
+        Auction auc = service.create(1L, req);
+        service.placeBid(auc.getId(), 2L, 100);
+        clock.set(Instant.parse("2025-10-02T00:00:00Z"));
+        AuctionWinner w = service.getWinner(auc.getId());
+        clock.set(clock.instant().plusSeconds(60*60*24 + 1)); // just past payDue
+        service.expirePayments();
+        assertEquals(AuctionWinner.PayStatus.EXPIRE, w.getPayStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- implement in-memory auction service with bid placement, winner calculation, and payment handling
- expose REST endpoints for auction CRUD, bidding, winner payment and cancellation
- schedule payment expiry job and tests for winner flow

## Testing
- `gradle test` *(fails: 403 Forbidden retrieving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be5b22b334832e9e2238ad65d194e9