### PR TITLE
feat: add admin policy management

### DIFF
--- a/src/main/java/com/rbox/admin/AdminAuthInterceptor.java
+++ b/src/main/java/com/rbox/admin/AdminAuthInterceptor.java
@@ -1,0 +1,18 @@
+package com.rbox.admin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AdminAuthInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        String role = request.getHeader("X-ROLE");
+        if (!"ADMIN".equals(role)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/rbox/admin/AdminWebConfig.java
+++ b/src/main/java/com/rbox/admin/AdminWebConfig.java
@@ -1,0 +1,13 @@
+package com.rbox.admin;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AdminWebConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminAuthInterceptor()).addPathPatterns("/admin/**");
+    }
+}

--- a/src/main/java/com/rbox/admin/policy/AdminPolicyController.java
+++ b/src/main/java/com/rbox/admin/policy/AdminPolicyController.java
@@ -1,0 +1,84 @@
+package com.rbox.admin.policy;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminPolicyController {
+    private final AdminPolicyService service;
+
+    // Market policies
+    @GetMapping("/market/policies")
+    public ApiResponse<Paged<MarketPolicy>> listMarket(@RequestParam(required = false) String useYn,
+                                                       @RequestParam(defaultValue = "1") int page,
+                                                       @RequestParam(defaultValue = "20") int size) {
+        return ApiResponse.success(service.listMarketPolicies(useYn, page, size));
+    }
+
+    @PutMapping("/market/policies/{polCd}")
+    public ApiResponse<MarketPolicy> upsertMarket(@RequestHeader("X-USER-ID") Long uid,
+                                                   @PathVariable String polCd,
+                                                   @Valid @RequestBody MarketPolicyRequest req) {
+        return ApiResponse.success(service.upsertMarketPolicy(polCd, req, uid));
+    }
+
+    @DeleteMapping("/market/policies/{polCd}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteMarket(@RequestHeader("X-USER-ID") Long uid,
+                             @PathVariable String polCd) {
+        service.deleteMarketPolicy(polCd, uid);
+    }
+
+    // Breeding policies
+    @GetMapping("/breeding/policies/{polCd}")
+    public ApiResponse<BreedingPolicy> getBreeding(@PathVariable String polCd) {
+        return ApiResponse.success(service.getBreedingPolicy(polCd));
+    }
+
+    @PutMapping("/breeding/policies/{polCd}")
+    public ApiResponse<BreedingPolicy> upsertBreeding(@RequestHeader("X-USER-ID") Long uid,
+                                                       @PathVariable String polCd,
+                                                       @Valid @RequestBody BreedingPolicyRequest req) {
+        return ApiResponse.success(service.upsertBreedingPolicy(polCd, req, uid));
+    }
+
+    // Quality policies
+    @GetMapping("/quality/policies/{polCd}")
+    public ApiResponse<QualityPolicy> getQuality(@PathVariable String polCd) {
+        return ApiResponse.success(service.getQualityPolicy(polCd));
+    }
+
+    @PutMapping("/quality/policies/{polCd}")
+    public ApiResponse<QualityPolicy> upsertQuality(@RequestHeader("X-USER-ID") Long uid,
+                                                     @PathVariable String polCd,
+                                                     @Valid @RequestBody QualityPolicyRequest req) {
+        return ApiResponse.success(service.upsertQualityPolicy(polCd, req, uid));
+    }
+
+    // Size policies
+    @GetMapping("/size/policies")
+    public ApiResponse<Iterable<SizePolicy>> listSize(@RequestParam String spcCd) {
+        return ApiResponse.success(service.listSizePolicies(spcCd));
+    }
+
+    @PutMapping("/size/policies/{spcCd}/{szCd}")
+    public ApiResponse<SizePolicy> upsertSize(@RequestHeader("X-USER-ID") Long uid,
+                                               @PathVariable String spcCd, @PathVariable String szCd,
+                                               @Valid @RequestBody SizePolicyRequest req) {
+        return ApiResponse.success(service.upsertSizePolicy(spcCd, szCd, req, uid));
+    }
+
+    @DeleteMapping("/size/policies/{spcCd}/{szCd}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteSize(@RequestHeader("X-USER-ID") Long uid,
+                           @PathVariable String spcCd, @PathVariable String szCd) {
+        service.deleteSizePolicy(spcCd, szCd, uid);
+    }
+}

--- a/src/main/java/com/rbox/admin/policy/AdminPolicyService.java
+++ b/src/main/java/com/rbox/admin/policy/AdminPolicyService.java
@@ -1,0 +1,114 @@
+package com.rbox.admin.policy;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminPolicyService {
+    private final Clock clock;
+
+    private final Map<String, MarketPolicy> marketPolicies = new ConcurrentHashMap<>();
+    private final Map<String, BreedingPolicy> breedingPolicies = new ConcurrentHashMap<>();
+    private final Map<String, QualityPolicy> qualityPolicies = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, SizePolicy>> sizePolicies = new ConcurrentHashMap<>();
+
+    private final List<AuditLog> auditLogs = new CopyOnWriteArrayList<>();
+    private final AtomicLong audSeq = new AtomicLong();
+
+    public AdminPolicyService(Clock clock) {
+        this.clock = clock;
+    }
+
+    public Paged<MarketPolicy> listMarketPolicies(String useYn, int page, int size) {
+        List<MarketPolicy> list = new ArrayList<>(marketPolicies.values());
+        if (useYn != null) {
+            list = list.stream().filter(p -> useYn.equals(p.useYn())).toList();
+        }
+        int total = list.size();
+        int from = Math.max(0, (page - 1) * size);
+        int to = Math.min(from + size, total);
+        List<MarketPolicy> content = from >= total ? List.of() : list.subList(from, to);
+        return new Paged<>(content, total, page, size);
+    }
+
+    public MarketPolicy upsertMarketPolicy(String polCd, MarketPolicyRequest req, Long uid) {
+        MarketPolicy old = marketPolicies.get(polCd);
+        MarketPolicy newer = new MarketPolicy(polCd, req.polVal(), req.useYn(), clock.instant());
+        marketPolicies.put(polCd, newer);
+        audit(uid, "POL_UPSERT", "tb_mkt_pol", polCd, Map.of("old", old, "new", newer));
+        return newer;
+    }
+
+    public void deleteMarketPolicy(String polCd, Long uid) {
+        MarketPolicy old = marketPolicies.remove(polCd);
+        audit(uid, "POL_DELETE", "tb_mkt_pol", polCd, Map.of("old", old, "new", null));
+    }
+
+    public BreedingPolicy getBreedingPolicy(String polCd) {
+        return breedingPolicies.get(polCd);
+    }
+
+    public BreedingPolicy upsertBreedingPolicy(String polCd, BreedingPolicyRequest req, Long uid) {
+        if (req.etaMin() > req.etaMax()) throw new IllegalArgumentException("etaMin <= etaMax");
+        BreedingPolicy old = breedingPolicies.get(polCd);
+        BreedingPolicy newer = new BreedingPolicy(polCd, req.etaMin(), req.etaMax(), req.cdlDay(), req.layGap());
+        breedingPolicies.put(polCd, newer);
+        audit(uid, "POL_UPSERT", "tb_brd_pol", polCd, Map.of("old", old, "new", newer));
+        return newer;
+    }
+
+    public QualityPolicy getQualityPolicy(String polCd) {
+        return qualityPolicies.get(polCd);
+    }
+
+    public QualityPolicy upsertQualityPolicy(String polCd, QualityPolicyRequest req, Long uid) {
+        if (req.g1Min() > req.g2Min() || req.g2Min() > req.g3Min())
+            throw new IllegalArgumentException("g1<=g2<=g3");
+        QualityPolicy old = qualityPolicies.get(polCd);
+        QualityPolicy newer = new QualityPolicy(polCd, req.g1Min(), req.g2Min(), req.g3Min(), req.rptPnlA(), req.rptPnlB());
+        qualityPolicies.put(polCd, newer);
+        audit(uid, "POL_UPSERT", "tb_qual_pol", polCd, Map.of("old", old, "new", newer));
+        return newer;
+    }
+
+    public List<SizePolicy> listSizePolicies(String spcCd) {
+        return new ArrayList<>(sizePolicies.getOrDefault(spcCd, Map.of()).values());
+    }
+
+    public SizePolicy upsertSizePolicy(String spcCd, String szCd, SizePolicyRequest req, Long uid) {
+        if (req.ageMin() != null && req.ageMax() != null && req.ageMin() > req.ageMax())
+            throw new IllegalArgumentException("ageMin <= ageMax");
+        if (req.wtMin() != null && req.wtMax() != null && req.wtMin() > req.wtMax())
+            throw new IllegalArgumentException("wtMin <= wtMax");
+        Map<String, SizePolicy> map = sizePolicies.computeIfAbsent(spcCd, k -> new ConcurrentHashMap<>());
+        SizePolicy old = map.get(szCd);
+        SizePolicy newer = new SizePolicy(spcCd, szCd, req.ageMin(), req.ageMax(), req.wtMin(), req.wtMax(), req.adjTp());
+        map.put(szCd, newer);
+        audit(uid, "SIZ_UPSERT", "tb_siz_pol", spcCd + ":" + szCd, Map.of("old", old, "new", newer));
+        return newer;
+    }
+
+    public void deleteSizePolicy(String spcCd, String szCd, Long uid) {
+        Map<String, SizePolicy> map = sizePolicies.get(spcCd);
+        if (map == null) return;
+        SizePolicy old = map.remove(szCd);
+        audit(uid, "SIZ_DELETE", "tb_siz_pol", spcCd + ":" + szCd, Map.of("old", old, "new", null));
+    }
+
+    public List<AuditLog> getAuditLogs() {
+        return auditLogs;
+    }
+
+    private void audit(Long uid, String actTp, String tgtTb, String tgtId, Map<String, Object> diff) {
+        long id = audSeq.incrementAndGet();
+        auditLogs.add(new AuditLog(id, uid, actTp, tgtTb, tgtId, diff, Instant.now(clock)));
+    }
+}

--- a/src/main/java/com/rbox/admin/policy/AuditLog.java
+++ b/src/main/java/com/rbox/admin/policy/AuditLog.java
@@ -1,0 +1,7 @@
+package com.rbox.admin.policy;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record AuditLog(long audId, Long uid, String actTp, String tgtTb, String tgtId,
+                       Map<String, Object> diffJs, Instant regDt) {}

--- a/src/main/java/com/rbox/admin/policy/BreedingPolicy.java
+++ b/src/main/java/com/rbox/admin/policy/BreedingPolicy.java
@@ -1,0 +1,3 @@
+package com.rbox.admin.policy;
+
+public record BreedingPolicy(String polCd, int etaMin, int etaMax, int cdlDay, int layGap) {}

--- a/src/main/java/com/rbox/admin/policy/BreedingPolicyRequest.java
+++ b/src/main/java/com/rbox/admin/policy/BreedingPolicyRequest.java
@@ -1,0 +1,9 @@
+package com.rbox.admin.policy;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record BreedingPolicyRequest(@NotNull @Min(0) Integer etaMin,
+                                    @NotNull @Min(0) Integer etaMax,
+                                    @NotNull @Min(0) Integer cdlDay,
+                                    @NotNull @Min(0) Integer layGap) {}

--- a/src/main/java/com/rbox/admin/policy/MarketPolicy.java
+++ b/src/main/java/com/rbox/admin/policy/MarketPolicy.java
@@ -1,0 +1,5 @@
+package com.rbox.admin.policy;
+
+import java.time.Instant;
+
+public record MarketPolicy(String polCd, String polVal, String useYn, Instant updDt) {}

--- a/src/main/java/com/rbox/admin/policy/MarketPolicyRequest.java
+++ b/src/main/java/com/rbox/admin/policy/MarketPolicyRequest.java
@@ -1,0 +1,8 @@
+package com.rbox.admin.policy;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MarketPolicyRequest(@NotBlank @Size(max = 100) String polVal,
+                                  @NotBlank @Pattern(regexp = "[YN]") String useYn) {}

--- a/src/main/java/com/rbox/admin/policy/Paged.java
+++ b/src/main/java/com/rbox/admin/policy/Paged.java
@@ -1,0 +1,5 @@
+package com.rbox.admin.policy;
+
+import java.util.List;
+
+public record Paged<T>(List<T> content, long total, int page, int size) {}

--- a/src/main/java/com/rbox/admin/policy/QualityPolicy.java
+++ b/src/main/java/com/rbox/admin/policy/QualityPolicy.java
@@ -1,0 +1,3 @@
+package com.rbox.admin.policy;
+
+public record QualityPolicy(String polCd, int g1Min, int g2Min, int g3Min, int rptPnlA, int rptPnlB) {}

--- a/src/main/java/com/rbox/admin/policy/QualityPolicyRequest.java
+++ b/src/main/java/com/rbox/admin/policy/QualityPolicyRequest.java
@@ -1,0 +1,10 @@
+package com.rbox.admin.policy;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record QualityPolicyRequest(@NotNull @Min(0) Integer g1Min,
+                                   @NotNull @Min(0) Integer g2Min,
+                                   @NotNull @Min(0) Integer g3Min,
+                                   @NotNull @Min(0) Integer rptPnlA,
+                                   @NotNull @Min(0) Integer rptPnlB) {}

--- a/src/main/java/com/rbox/admin/policy/SizePolicy.java
+++ b/src/main/java/com/rbox/admin/policy/SizePolicy.java
@@ -1,0 +1,4 @@
+package com.rbox.admin.policy;
+
+public record SizePolicy(String spcCd, String szCd, Integer ageMin, Integer ageMax,
+                         Double wtMin, Double wtMax, String adjTp) {}

--- a/src/main/java/com/rbox/admin/policy/SizePolicyRequest.java
+++ b/src/main/java/com/rbox/admin/policy/SizePolicyRequest.java
@@ -1,0 +1,8 @@
+package com.rbox.admin.policy;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SizePolicyRequest(Integer ageMin, Integer ageMax,
+                                Double wtMin, Double wtMax,
+                                @NotBlank @Pattern(regexp = "AGE|WT|BOTH") String adjTp) {}


### PR DESCRIPTION
## Summary
- add in-memory services and controllers for admin policy CRUD
- record simple audit logs on policy changes
- protect /admin endpoints with interceptor checking ADMIN role

## Testing
- `gradle -q test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-validation:3.2.2, received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be5ca9dad4832ea8c52fcf37595421