### PR TITLE
feat: add v2 search and org controllers

### DIFF
--- a/docs/v2_org.sql
+++ b/docs/v2_org.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS tb_org (
+  org_id   BIGINT AUTO_INCREMENT COMMENT '조직ID',
+  org_nm   VARCHAR(120) NOT NULL COMMENT '조직명',
+  org_tp   VARCHAR(20) NOT NULL DEFAULT 'SHOP' COMMENT '유형(SHOP/TEAM)',
+  stat_cd  VARCHAR(20) NOT NULL DEFAULT 'ACTV' COMMENT '상태',
+  reg_dt   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록',
+  PRIMARY KEY pk_tb_org (org_id),
+  KEY idx_tb_org_tp (org_tp, stat_cd)
+) ENGINE=InnoDB COMMENT='조직(샵/팀)';
+
+CREATE TABLE IF NOT EXISTS tb_org_usr (
+  org_id   BIGINT NOT NULL COMMENT '조직ID',
+  usr_id   BIGINT NOT NULL COMMENT '사용자ID',
+  role_cd  VARCHAR(20) NOT NULL COMMENT '역할(OWNER/ADMIN/EDITOR/VIEWER)',
+  reg_dt   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '등록',
+  PRIMARY KEY pk_tb_org_usr (org_id, usr_id),
+  KEY idx_tb_org_usr_role (role_cd)
+) ENGINE=InnoDB COMMENT='조직-사용자';
+
+-- 리소스에 조직 소유 필드 추가 (NULL 허용)
+ALTER TABLE tb_obj      ADD COLUMN own_org_id BIGINT NULL COMMENT '소유조직ID' AFTER own_usr_id;
+ALTER TABLE tb_mkt_lst  ADD COLUMN own_org_id BIGINT NULL COMMENT '소유조직ID' AFTER obj_id;
+ALTER TABLE tb_auc      ADD COLUMN own_org_id BIGINT NULL COMMENT '소유조직ID' AFTER obj_id;

--- a/openapi-search-orgs-v2.yaml
+++ b/openapi-search-orgs-v2.yaml
@@ -1,0 +1,183 @@
+openapi: 3.0.3
+info:
+  title: RBOX Search & Orgs API
+  version: 2.0.0
+  description: >
+    검색/필터 고도화 및 조직 권한 v2 API.
+    공통 응답 래퍼: ApiResponse<T> = { data, meta?, error? }
+servers:
+  - url: http://localhost:8080
+
+tags:
+  - name: Search
+    description: 고급 검색
+  - name: Orgs
+    description: 조직 및 컨텍스트
+  - name: Objects
+    description: 개체
+
+paths:
+  /v2/search/listings:
+    get:
+      tags: [Search]
+      summary: 고급 검색(판매/경매)
+      parameters:
+        - in: query
+          name: type
+          schema: { type: string, enum: [LISTING, AUCTION, ALL], default: ALL }
+        - in: query
+          name: spcCd
+          schema: { type: string }
+        - in: query
+          name: sexCd
+          schema: { type: string }
+        - in: query
+          name: sizeCd
+          schema: { type: string }
+        - in: query
+          name: priceMin
+          schema: { type: number }
+        - in: query
+          name: priceMax
+          schema: { type: number }
+        - in: query
+          name: qualLv
+          schema: { type: string }
+        - in: query
+          name: profLv
+          schema: { type: string }
+        - in: query
+          name: morphMode
+          schema: { type: string, enum: [ANY, ALL], default: ANY }
+        - in: query
+          name: morphCat
+          schema: { type: string }
+        - in: query
+          name: morphIds
+          schema: { type: string, description: "CSV of mphId" }
+        - in: query
+          name: hasImage
+          schema: { type: boolean }
+        - in: query
+          name: ownerUserId
+          schema: { type: integer, format: int64 }
+        - in: query
+          name: sort
+          schema: { type: string, default: "-regDt" }
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: size
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        '200': { description: OK }
+
+  /v2/search/objects:
+    get:
+      tags: [Search]
+      summary: 고급 검색(개체)
+      parameters:
+        - in: query
+          name: spcCd
+          schema: { type: string }
+        - in: query
+          name: sexCd
+          schema: { type: string }
+        - in: query
+          name: sizeCd
+          schema: { type: string }
+        - in: query
+          name: morphMode
+          schema: { type: string, enum: [ANY, ALL], default: ANY }
+        - in: query
+          name: morphIds
+          schema: { type: string }
+        - in: query
+          name: sort
+          schema: { type: string, enum: [-quality, -likes, -regDt], default: -regDt }
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: size
+          schema: { type: integer, default: 20 }
+      responses:
+        '200': { description: OK }
+
+  /v2/orgs:
+    post:
+      tags: [Orgs]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [orgNm]
+              properties:
+                orgNm: { type: string }
+                orgTp: { type: string, enum: [SHOP, TEAM], default: SHOP }
+      responses: { '201': { description: Created } }
+    get:
+      tags: [Orgs]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: OK } }
+
+  /v2/orgs/{orgId}/members:
+    post:
+      tags: [Orgs]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: orgId
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, roleCd]
+              properties:
+                userId: { type: integer, format: int64 }
+                roleCd: { type: string, enum: [OWNER, ADMIN, EDITOR, VIEWER] }
+      responses: { '201': { description: Added } }
+
+  /v2/context:
+    get:
+      tags: [Orgs]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: OK } }
+
+  /v2/objects:
+    post:
+      tags: [Objects]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: header
+          name: X-RBOX-ORG-ID
+          required: false
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [spcCd, sexCd]
+              properties:
+                spcCd: { type: string }
+                name: { type: string }
+                sexCd: { type: string }
+                ownerType: { type: string, enum: [USER, ORG] }
+      responses: { '201': { description: Created } }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/src/main/java/com/rbox/org/v2/OrgService.java
+++ b/src/main/java/com/rbox/org/v2/OrgService.java
@@ -1,0 +1,59 @@
+package com.rbox.org.v2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * In-memory organization service. This is intentionally simplistic and exists
+ * only so that the REST layer has something to interact with.
+ */
+@Service
+public class OrgService {
+    private final AtomicLong seq = new AtomicLong(1);
+    private final Map<Long, Org> orgs = new ConcurrentHashMap<>();
+    private final Map<Long, Map<Long, String>> members = new ConcurrentHashMap<>();
+
+    public Org createOrg(Long ownerId, String orgNm, String orgTp) {
+        long id = seq.getAndIncrement();
+        Org org = new Org(id, orgNm, orgTp);
+        orgs.put(id, org);
+        members.computeIfAbsent(id, k -> new ConcurrentHashMap<>()).put(ownerId, "OWNER");
+        return org;
+    }
+
+    public List<Org> listOrgs(Long userId) {
+        List<Org> list = new ArrayList<>();
+        members.forEach((orgId, m) -> {
+            if (m.containsKey(userId)) {
+                list.add(orgs.get(orgId));
+            }
+        });
+        return list;
+    }
+
+    public void addMember(Long orgId, Long userId, String roleCd) {
+        members.computeIfAbsent(orgId, k -> new ConcurrentHashMap<>()).put(userId, roleCd);
+    }
+
+    public void changeMember(Long orgId, Long userId, String roleCd) {
+        Map<Long, String> m = members.get(orgId);
+        if (m != null) {
+            m.put(userId, roleCd);
+        }
+    }
+
+    public void deleteMember(Long orgId, Long userId) {
+        Map<Long, String> m = members.get(orgId);
+        if (m != null) {
+            m.remove(userId);
+        }
+    }
+
+    public record Org(Long orgId, String orgNm, String orgTp) {}
+}
+

--- a/src/main/java/com/rbox/org/v2/OrgV2Controller.java
+++ b/src/main/java/com/rbox/org/v2/OrgV2Controller.java
@@ -1,0 +1,81 @@
+package com.rbox.org.v2;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+
+/**
+ * Controller for organization management APIs (v2).
+ */
+@RestController
+@RequestMapping("/v2")
+@RequiredArgsConstructor
+public class OrgV2Controller {
+    private final OrgService service;
+
+    private Long getUserId(String header) {
+        return header == null ? null : Long.valueOf(header);
+    }
+
+    @PostMapping("/orgs")
+    public ApiResponse<Map<String, Long>> createOrg(@RequestHeader("X-USER-ID") String user,
+            @RequestBody Map<String, String> body) {
+        String orgNm = body.getOrDefault("orgNm", "");
+        String orgTp = body.getOrDefault("orgTp", "SHOP");
+        OrgService.Org org = service.createOrg(getUserId(user), orgNm, orgTp);
+        return ApiResponse.success(Map.of("orgId", org.orgId()));
+    }
+
+    @GetMapping("/orgs")
+    public ApiResponse<List<OrgService.Org>> listOrgs(@RequestHeader("X-USER-ID") String user) {
+        List<OrgService.Org> list = service.listOrgs(getUserId(user));
+        return ApiResponse.success(list);
+    }
+
+    @PostMapping("/orgs/{orgId}/members")
+    public ApiResponse<Void> addMember(@PathVariable Long orgId, @RequestBody Map<String, Object> body) {
+        Long userId = ((Number) body.get("userId")).longValue();
+        String roleCd = (String) body.get("roleCd");
+        service.addMember(orgId, userId, roleCd);
+        return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/orgs/{orgId}/members/{userId}")
+    public ApiResponse<Void> changeMember(@PathVariable Long orgId, @PathVariable Long userId,
+            @RequestBody Map<String, String> body) {
+        String roleCd = body.get("roleCd");
+        service.changeMember(orgId, userId, roleCd);
+        return ApiResponse.success(null);
+    }
+
+    @DeleteMapping("/orgs/{orgId}/members/{userId}")
+    public ApiResponse<Void> deleteMember(@PathVariable Long orgId, @PathVariable Long userId) {
+        service.deleteMember(orgId, userId);
+        return ApiResponse.success(null);
+    }
+
+    @GetMapping("/context")
+    public ApiResponse<Map<String, Object>> context(
+            @RequestHeader(value = "X-USER-ID", required = false) String user,
+            @RequestHeader(value = "X-RBOX-ORG-ID", required = false) String org) {
+        Map<String, Object> data = new HashMap<>();
+        if (user != null) data.put("userId", Long.valueOf(user));
+        if (org != null) data.put("orgId", Long.valueOf(org));
+        return ApiResponse.success(data);
+    }
+}
+

--- a/src/main/java/com/rbox/search/v2/SearchListingsRequest.java
+++ b/src/main/java/com/rbox/search/v2/SearchListingsRequest.java
@@ -1,0 +1,26 @@
+package com.rbox.search.v2;
+
+import java.math.BigDecimal;
+
+/**
+ * Parameters for the listing search endpoint. Only a subset of the
+ * documented fields are captured to keep the example concise.
+ */
+public record SearchListingsRequest(
+        String type,
+        String spcCd,
+        String sexCd,
+        String sizeCd,
+        BigDecimal priceMin,
+        BigDecimal priceMax,
+        String morphMode,
+        String morphCat,
+        String morphIds,
+        Boolean hasImage,
+        Long ownerUserId,
+        Long ownerOrgId,
+        String sort,
+        int page,
+        int size) {
+}
+

--- a/src/main/java/com/rbox/search/v2/SearchObjectsRequest.java
+++ b/src/main/java/com/rbox/search/v2/SearchObjectsRequest.java
@@ -1,0 +1,17 @@
+package com.rbox.search.v2;
+
+/**
+ * Parameters for the object search endpoint. It mirrors the listing search
+ * but with fewer fields.
+ */
+public record SearchObjectsRequest(
+        String spcCd,
+        String sexCd,
+        String sizeCd,
+        String morphMode,
+        String morphIds,
+        String sort,
+        int page,
+        int size) {
+}
+

--- a/src/main/java/com/rbox/search/v2/SearchService.java
+++ b/src/main/java/com/rbox/search/v2/SearchService.java
@@ -1,0 +1,27 @@
+package com.rbox.search.v2;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Very lightweight service backing the v2 search endpoints.
+ * <p>
+ * It does not query a database; instead it returns empty results so that
+ * the API surface is in place for further evolution.
+ */
+@Service
+public class SearchService {
+    public SearchResult searchListings(SearchListingsRequest req) {
+        return new SearchResult(Collections.emptyList(), 0, req.page(), req.size());
+    }
+
+    public SearchResult searchObjects(SearchObjectsRequest req) {
+        return new SearchResult(Collections.emptyList(), 0, req.page(), req.size());
+    }
+
+    public record SearchResult(List<Map<String, Object>> content, long total, int page, int size) {}
+}
+

--- a/src/main/java/com/rbox/search/v2/SearchV2Controller.java
+++ b/src/main/java/com/rbox/search/v2/SearchV2Controller.java
@@ -1,0 +1,74 @@
+package com.rbox.search.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+
+/**
+ * Controller exposing the v2 search endpoints.
+ */
+@RestController
+@RequestMapping("/v2/search")
+@RequiredArgsConstructor
+public class SearchV2Controller {
+    private final SearchService service;
+
+    @GetMapping("/listings")
+    public ApiResponse<Map<String, Object>> listings(
+            @RequestParam(required = false, defaultValue = "ALL") String type,
+            @RequestParam(required = false) String spcCd,
+            @RequestParam(required = false) String sexCd,
+            @RequestParam(required = false) String sizeCd,
+            @RequestParam(required = false) Double priceMin,
+            @RequestParam(required = false) Double priceMax,
+            @RequestParam(required = false, defaultValue = "ANY") String morphMode,
+            @RequestParam(required = false) String morphCat,
+            @RequestParam(required = false) String morphIds,
+            @RequestParam(required = false) Boolean hasImage,
+            @RequestParam(required = false) Long ownerUserId,
+            @RequestParam(required = false) Long ownerOrgId,
+            @RequestParam(required = false, defaultValue = "-regDt") String sort,
+            @RequestParam(required = false, defaultValue = "1") Integer page,
+            @RequestParam(required = false, defaultValue = "20") Integer size) {
+        SearchListingsRequest req = new SearchListingsRequest(type, spcCd, sexCd, sizeCd,
+                priceMin == null ? null : java.math.BigDecimal.valueOf(priceMin),
+                priceMax == null ? null : java.math.BigDecimal.valueOf(priceMax),
+                morphMode, morphCat, morphIds, hasImage, ownerUserId, ownerOrgId, sort, page, size);
+        SearchService.SearchResult result = service.searchListings(req);
+        Map<String, Object> data = new HashMap<>();
+        data.put("content", result.content());
+        data.put("total", result.total());
+        data.put("page", result.page());
+        data.put("size", result.size());
+        return ApiResponse.success(data);
+    }
+
+    @GetMapping("/objects")
+    public ApiResponse<Map<String, Object>> objects(
+            @RequestParam(required = false) String spcCd,
+            @RequestParam(required = false) String sexCd,
+            @RequestParam(required = false) String sizeCd,
+            @RequestParam(required = false, defaultValue = "ANY") String morphMode,
+            @RequestParam(required = false) String morphIds,
+            @RequestParam(required = false, defaultValue = "-regDt") String sort,
+            @RequestParam(required = false, defaultValue = "1") Integer page,
+            @RequestParam(required = false, defaultValue = "20") Integer size) {
+        SearchObjectsRequest req = new SearchObjectsRequest(spcCd, sexCd, sizeCd, morphMode, morphIds, sort, page, size);
+        SearchService.SearchResult result = service.searchObjects(req);
+        Map<String, Object> data = new HashMap<>();
+        data.put("content", result.content());
+        data.put("total", result.total());
+        data.put("page", result.page());
+        data.put("size", result.size());
+        return ApiResponse.success(data);
+    }
+}
+


### PR DESCRIPTION
## Summary
- document advanced listing/object search parameters and organization APIs
- add stub controllers and services for v2 search and organization management

## Testing
- `gradle test` *(fails: Could not GET https://repo.maven.apache.org/... 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be67a1dcfc832ea7588d0d99836593