### PR TITLE
feat: add mybatis mappers

### DIFF
--- a/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/ClutchRepository.java
+++ b/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/ClutchRepository.java
@@ -3,14 +3,18 @@ package com.rbox.breeding.adapter.out.persistence.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
 /**
  * 클러치 정보를 저장/조회하기 위한 저장소 인터페이스.
  */
+@Mapper
 public interface ClutchRepository {
     Long save(ClutchEntity entity);
-    Optional<ClutchEntity> findById(Long id);
-    List<ClutchEntity> findByFemObjId(Long femObjId);
-    List<ClutchEntity> findByMatId(Long matId);
+    Optional<ClutchEntity> findById(@Param("id") Long id);
+    List<ClutchEntity> findByFemObjId(@Param("femObjId") Long femObjId);
+    List<ClutchEntity> findByMatId(@Param("matId") Long matId);
     void update(ClutchEntity entity);
 }
 

--- a/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/InMemoryClutchRepository.java
+++ b/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/InMemoryClutchRepository.java
@@ -7,12 +7,9 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.springframework.stereotype.Repository;
-
 /**
  * 메모리에 클러치 정보를 저장하는 구현체.
  */
-@Repository
 public class InMemoryClutchRepository implements ClutchRepository {
     private final Map<Long, ClutchEntity> store = new ConcurrentHashMap<>();
     private final AtomicLong seq = new AtomicLong(1);

--- a/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/InMemoryPairingRepository.java
+++ b/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/InMemoryPairingRepository.java
@@ -7,12 +7,9 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.springframework.stereotype.Repository;
-
 /**
  * 메모리에 메이팅 정보를 저장하는 구현체.
  */
-@Repository
 public class InMemoryPairingRepository implements PairingRepository {
     private final Map<Long, PairingEntity> store = new ConcurrentHashMap<>();
     private final AtomicLong seq = new AtomicLong(1);

--- a/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/PairingRepository.java
+++ b/src/main/java/com/rbox/breeding/adapter/out/persistence/repository/PairingRepository.java
@@ -3,12 +3,16 @@ package com.rbox.breeding.adapter.out.persistence.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
 /**
  * 메이팅 정보를 저장/조회하기 위한 저장소 인터페이스.
  */
+@Mapper
 public interface PairingRepository {
     Long save(PairingEntity entity);
-    Optional<PairingEntity> findById(Long id);
-    List<PairingEntity> findByFemObjId(Long femObjId);
+    Optional<PairingEntity> findById(@Param("id") Long id);
+    List<PairingEntity> findByFemObjId(@Param("femObjId") Long femObjId);
 }
 

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectImageRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectImageRepository.java
@@ -6,12 +6,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.springframework.stereotype.Repository;
-
 /**
  * 메모리에 개체 이미지를 저장하는 테스트용 구현체.
  */
-@Repository
 public class InMemoryObjectImageRepository implements ObjectImageRepository {
     private final Map<Long, List<ObjectImageEntity>> store = new HashMap<>();
     private final AtomicLong seq = new AtomicLong(1);

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/InMemoryObjectRepository.java
@@ -7,12 +7,9 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.springframework.stereotype.Repository;
-
 /**
  * 메모리에 개체 정보를 저장하는 테스트용 구현체.
  */
-@Repository
 public class InMemoryObjectRepository implements ObjectRepository {
     private final Map<Long, ObjectEntity> store = new ConcurrentHashMap<>();
     private final AtomicLong seq = new AtomicLong(1);

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectImageRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectImageRepository.java
@@ -2,9 +2,13 @@ package com.rbox.object.adapter.out.persistence.repository;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
 /**
  * 개체 이미지 저장소 인터페이스.
  */
+@Mapper
 public interface ObjectImageRepository {
 
     /**
@@ -18,11 +22,11 @@ public interface ObjectImageRepository {
     /**
      * 개체 ID로 이미지 목록을 조회한다.
      */
-    List<ObjectImageEntity> findByObjectId(Long objId);
+    List<ObjectImageEntity> findByObjectId(@Param("objId") Long objId);
 
     /**
      * 이미지 ID로 이미지를 삭제한다.
      */
-    void delete(Long imgId);
+    void delete(@Param("imgId") Long imgId);
 }
 

--- a/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectRepository.java
+++ b/src/main/java/com/rbox/object/adapter/out/persistence/repository/ObjectRepository.java
@@ -3,9 +3,13 @@ package com.rbox.object.adapter.out.persistence.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
 /**
  * 개체 정보를 저장/조회하기 위한 저장소 인터페이스.
  */
+@Mapper
 public interface ObjectRepository {
 
     /**
@@ -22,7 +26,7 @@ public interface ObjectRepository {
      * @param id 개체 ID
      * @return 개체 정보
      */
-    Optional<ObjectEntity> findById(Long id);
+    Optional<ObjectEntity> findById(@Param("id") Long id);
 
     /**
      * 소유자 ID로 개체 목록을 조회한다.
@@ -30,7 +34,7 @@ public interface ObjectRepository {
      * @param ownerId 소유자 ID
      * @return 개체 목록
      */
-    List<ObjectEntity> findByOwner(Long ownerId);
+    List<ObjectEntity> findByOwner(@Param("ownerId") Long ownerId);
 
     /**
      * 개체 정보를 갱신한다.
@@ -40,6 +44,6 @@ public interface ObjectRepository {
     /**
      * 개체를 삭제한다.
      */
-    void delete(Long id);
+    void delete(@Param("id") Long id);
 }
 

--- a/src/main/resources/mybatis/breeding/ClutchRepository.xml
+++ b/src/main/resources/mybatis/breeding/ClutchRepository.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.rbox.breeding.adapter.out.persistence.repository.ClutchRepository">
+  <resultMap id="ClutchMap" type="com.rbox.breeding.adapter.out.persistence.repository.ClutchEntity">
+    <id property="id" column="clt_id" />
+    <result property="matId" column="mat_id" />
+    <result property="femObjId" column="fem_obj_id" />
+    <result property="cltNo" column="clt_no" />
+    <result property="layYmd" column="lay_ymd" />
+    <result property="eggCount" column="egg_count" />
+    <result property="statCd" column="stat_cd" />
+    <result property="chkYn" column="chk_yn" />
+  </resultMap>
+
+  <insert id="save" parameterType="com.rbox.breeding.adapter.out.persistence.repository.ClutchEntity" useGeneratedKeys="true" keyProperty="id" keyColumn="clt_id">
+    INSERT INTO tb_clt (mat_id, fem_obj_id, clt_no, lay_ymd, egg_count, stat_cd, chk_yn)
+    VALUES (#{matId}, #{femObjId}, #{cltNo}, #{layYmd}, #{eggCount}, #{statCd}, #{chkYn})
+  </insert>
+
+  <select id="findById" parameterType="long" resultMap="ClutchMap">
+    SELECT clt_id, mat_id, fem_obj_id, clt_no, lay_ymd, egg_count, stat_cd, chk_yn
+    FROM tb_clt
+    WHERE clt_id = #{id}
+  </select>
+
+  <select id="findByFemObjId" parameterType="long" resultMap="ClutchMap">
+    SELECT clt_id, mat_id, fem_obj_id, clt_no, lay_ymd, egg_count, stat_cd, chk_yn
+    FROM tb_clt
+    WHERE fem_obj_id = #{femObjId}
+    ORDER BY clt_no
+  </select>
+
+  <select id="findByMatId" parameterType="long" resultMap="ClutchMap">
+    SELECT clt_id, mat_id, fem_obj_id, clt_no, lay_ymd, egg_count, stat_cd, chk_yn
+    FROM tb_clt
+    WHERE mat_id = #{matId}
+    ORDER BY clt_no
+  </select>
+
+  <update id="update" parameterType="com.rbox.breeding.adapter.out.persistence.repository.ClutchEntity">
+    UPDATE tb_clt
+    SET mat_id = #{matId},
+        fem_obj_id = #{femObjId},
+        clt_no = #{cltNo},
+        lay_ymd = #{layYmd},
+        egg_count = #{eggCount},
+        stat_cd = #{statCd},
+        chk_yn = #{chkYn}
+    WHERE clt_id = #{id}
+  </update>
+</mapper>

--- a/src/main/resources/mybatis/breeding/PairingRepository.xml
+++ b/src/main/resources/mybatis/breeding/PairingRepository.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.rbox.breeding.adapter.out.persistence.repository.PairingRepository">
+  <resultMap id="PairingMap" type="com.rbox.breeding.adapter.out.persistence.repository.PairingEntity">
+    <id property="id" column="mat_id" />
+    <result property="femObjId" column="fem_obj_id" />
+    <result property="malObjId" column="mal_obj_id" />
+    <result property="matDt" column="mat_dt" />
+    <result property="statCd" column="stat_cd" />
+    <result property="note" column="note" />
+  </resultMap>
+
+  <insert id="save" parameterType="com.rbox.breeding.adapter.out.persistence.repository.PairingEntity" useGeneratedKeys="true" keyProperty="id" keyColumn="mat_id">
+    INSERT INTO tb_mat (fem_obj_id, mal_obj_id, mat_dt, stat_cd, note)
+    VALUES (#{femObjId}, #{malObjId}, #{matDt}, #{statCd}, #{note})
+  </insert>
+
+  <select id="findById" parameterType="long" resultMap="PairingMap">
+    SELECT mat_id, fem_obj_id, mal_obj_id, mat_dt, stat_cd, note
+    FROM tb_mat
+    WHERE mat_id = #{id}
+  </select>
+
+  <select id="findByFemObjId" parameterType="long" resultMap="PairingMap">
+    SELECT mat_id, fem_obj_id, mal_obj_id, mat_dt, stat_cd, note
+    FROM tb_mat
+    WHERE fem_obj_id = #{femObjId}
+    ORDER BY mat_dt DESC
+  </select>
+</mapper>

--- a/src/main/resources/mybatis/object/ObjectImageRepository.xml
+++ b/src/main/resources/mybatis/object/ObjectImageRepository.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.rbox.object.adapter.out.persistence.repository.ObjectImageRepository">
+  <resultMap id="ObjectImageMap" type="com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity">
+    <id property="imgId" column="img_id" />
+    <result property="objId" column="obj_id" />
+    <result property="url" column="url" />
+    <result property="ordNo" column="ord_no" />
+  </resultMap>
+
+  <insert id="save" parameterType="com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity" useGeneratedKeys="true" keyProperty="imgId" keyColumn="img_id">
+    INSERT INTO tb_obj_img (obj_id, url, ord_no)
+    VALUES (#{objId}, #{url}, #{ordNo})
+  </insert>
+
+  <select id="findByObjectId" parameterType="long" resultMap="ObjectImageMap">
+    SELECT img_id, obj_id, url, ord_no
+    FROM tb_obj_img
+    WHERE obj_id = #{objId}
+    ORDER BY ord_no
+  </select>
+
+  <delete id="delete" parameterType="long">
+    DELETE FROM tb_obj_img WHERE img_id = #{imgId}
+  </delete>
+</mapper>

--- a/src/main/resources/mybatis/object/ObjectRepository.xml
+++ b/src/main/resources/mybatis/object/ObjectRepository.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.rbox.object.adapter.out.persistence.repository.ObjectRepository">
+  <resultMap id="ObjectMap" type="com.rbox.object.adapter.out.persistence.repository.ObjectEntity">
+    <id property="id" column="obj_id" />
+    <result property="spcCd" column="spc_cd" />
+    <result property="name" column="name" />
+    <result property="sexCd" column="sex_cd" />
+    <result property="bthYmd" column="bth_ymd" />
+    <result property="objMode" column="obj_mode" />
+    <result property="statCd" column="stat_cd" />
+    <result property="marketOk" column="market_ok" />
+    <result property="ownUsrId" column="own_usr_id" />
+  </resultMap>
+
+  <insert id="save" parameterType="com.rbox.object.adapter.out.persistence.repository.ObjectEntity" useGeneratedKeys="true" keyProperty="id" keyColumn="obj_id">
+    INSERT INTO tb_obj (spc_cd, name, sex_cd, bth_ymd, obj_mode, stat_cd, market_ok, own_usr_id)
+    VALUES (#{spcCd}, #{name}, #{sexCd}, #{bthYmd}, #{objMode}, #{statCd}, #{marketOk}, #{ownUsrId})
+  </insert>
+
+  <select id="findById" parameterType="long" resultMap="ObjectMap">
+    SELECT obj_id, spc_cd, name, sex_cd, bth_ymd, obj_mode, stat_cd, market_ok, own_usr_id
+    FROM tb_obj
+    WHERE obj_id = #{id}
+  </select>
+
+  <select id="findByOwner" parameterType="long" resultMap="ObjectMap">
+    SELECT obj_id, spc_cd, name, sex_cd, bth_ymd, obj_mode, stat_cd, market_ok, own_usr_id
+    FROM tb_obj
+    WHERE own_usr_id = #{ownerId}
+    ORDER BY obj_id
+  </select>
+
+  <update id="update" parameterType="com.rbox.object.adapter.out.persistence.repository.ObjectEntity">
+    UPDATE tb_obj
+    SET spc_cd = #{spcCd},
+        name = #{name},
+        sex_cd = #{sexCd},
+        bth_ymd = #{bthYmd},
+        obj_mode = #{objMode},
+        stat_cd = #{statCd},
+        market_ok = #{marketOk}
+    WHERE obj_id = #{id}
+  </update>
+
+  <delete id="delete" parameterType="long">
+    DELETE FROM tb_obj WHERE obj_id = #{id}
+  </delete>
+</mapper>


### PR DESCRIPTION
## Summary
- add MyBatis mapper interfaces and SQL for breeding clutches and pairings
- implement MyBatis persistence for objects and object images
- drop `@Repository` from in-memory repositories to avoid bean conflicts

## Testing
- `gradle test` *(fails: Could not GET com.google.zxing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68be721e54b8832ea6bae95a82899806