### PR TITLE
Add Swagger UI and document auth endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'com.google.zxing:core:3.5.2'
     implementation 'com.google.zxing:javase:3.5.2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/rbox/auth/adapter/in/web/AuthWebCtr.java
+++ b/src/main/java/com/rbox/auth/adapter/in/web/AuthWebCtr.java
@@ -5,6 +5,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +23,7 @@ import com.rbox.common.api.ApiResponse;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(name = "Authentication", description = "인증 관련 API")
 public class AuthWebCtr {
     private final AuthUseCase useCase;
 
@@ -29,6 +33,7 @@ public class AuthWebCtr {
      * <p>출력: access/refresh 토큰이 포함된 {@link TokenResp}</p>
      */
     @PostMapping("/login")
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 이용하여 로그인합니다")
     public ApiResponse<TokenResp> login(@Valid @RequestBody LoginReq req) {
         return ApiResponse.success(useCase.login(new LoginCommand(req.email(), req.password())));
     }
@@ -39,6 +44,7 @@ public class AuthWebCtr {
      * <p>출력: 새로운 access 토큰이 포함된 {@link TokenResp}</p>
      */
     @PostMapping("/refresh")
+    @Operation(summary = "토큰 갱신", description = "리프레시 토큰으로 새 액세스 토큰을 발급합니다")
     public ApiResponse<TokenResp> refresh(@Valid @RequestBody RefreshReq req) {
         return ApiResponse.success(useCase.refresh(new RefreshCommand(req.refreshToken())));
     }

--- a/src/main/java/com/rbox/auth/adapter/in/web/LoginReq.java
+++ b/src/main/java/com/rbox/auth/adapter/in/web/LoginReq.java
@@ -4,7 +4,10 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "로그인 요청")
 public record LoginReq(
-        @Email @NotBlank String email,
-        @NotBlank @Size(min = 8, max = 128) String password
+        @Schema(description = "사용자 이메일", example = "user@example.com") @Email @NotBlank String email,
+        @Schema(description = "비밀번호", example = "Pa55w0rd!") @NotBlank @Size(min = 8, max = 128) String password
 ) {}

--- a/src/main/java/com/rbox/auth/adapter/in/web/RefreshReq.java
+++ b/src/main/java/com/rbox/auth/adapter/in/web/RefreshReq.java
@@ -2,4 +2,9 @@ package com.rbox.auth.adapter.in.web;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record RefreshReq(@NotBlank String refreshToken) {}
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "토큰 갱신 요청")
+public record RefreshReq(
+        @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9") @NotBlank String refreshToken
+) {}


### PR DESCRIPTION
## Summary
- integrate springdoc-openapi UI to expose Swagger documentation
- annotate auth controller endpoints with OpenAPI tags and operation details
- document login and refresh request models with schema descriptions and examples

## Testing
- `gradle test` *(fails: Could not resolve org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0 - Received status code 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68be7460d6ac832eb3bf765095278a75