### PR TITLE
Add Swagger annotations to all Web controllers

### DIFF
--- a/src/main/java/com/rbox/admin/policy/AdminPolicyController.java
+++ b/src/main/java/com/rbox/admin/policy/AdminPolicyController.java
@@ -8,14 +8,19 @@ import lombok.RequiredArgsConstructor;
 
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @RestController
 @RequestMapping("/admin")
 @RequiredArgsConstructor
+@Tag(name = "Admin Policy", description = "관리자 정책 API")
 public class AdminPolicyController {
     private final AdminPolicyService service;
 
     // Market policies
     @GetMapping("/market/policies")
+    @Operation(summary = "마켓 정책 목록", description = "마켓 정책 목록을 조회합니다")
     public ApiResponse<Paged<MarketPolicy>> listMarket(@RequestParam(required = false) String useYn,
                                                        @RequestParam(defaultValue = "1") int page,
                                                        @RequestParam(defaultValue = "20") int size) {
@@ -23,6 +28,7 @@ public class AdminPolicyController {
     }
 
     @PutMapping("/market/policies/{polCd}")
+    @Operation(summary = "마켓 정책 등록/수정", description = "마켓 정책을 등록하거나 수정합니다")
     public ApiResponse<MarketPolicy> upsertMarket(@RequestHeader("X-USER-ID") Long uid,
                                                    @PathVariable String polCd,
                                                    @Valid @RequestBody MarketPolicyRequest req) {
@@ -31,6 +37,7 @@ public class AdminPolicyController {
 
     @DeleteMapping("/market/policies/{polCd}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "마켓 정책 삭제", description = "마켓 정책을 삭제합니다")
     public void deleteMarket(@RequestHeader("X-USER-ID") Long uid,
                              @PathVariable String polCd) {
         service.deleteMarketPolicy(polCd, uid);
@@ -38,11 +45,13 @@ public class AdminPolicyController {
 
     // Breeding policies
     @GetMapping("/breeding/policies/{polCd}")
+    @Operation(summary = "브리딩 정책 조회", description = "브리딩 정책을 조회합니다")
     public ApiResponse<BreedingPolicy> getBreeding(@PathVariable String polCd) {
         return ApiResponse.success(service.getBreedingPolicy(polCd));
     }
 
     @PutMapping("/breeding/policies/{polCd}")
+    @Operation(summary = "브리딩 정책 등록/수정", description = "브리딩 정책을 등록하거나 수정합니다")
     public ApiResponse<BreedingPolicy> upsertBreeding(@RequestHeader("X-USER-ID") Long uid,
                                                        @PathVariable String polCd,
                                                        @Valid @RequestBody BreedingPolicyRequest req) {
@@ -51,11 +60,13 @@ public class AdminPolicyController {
 
     // Quality policies
     @GetMapping("/quality/policies/{polCd}")
+    @Operation(summary = "퀄리티 정책 조회", description = "퀄리티 정책을 조회합니다")
     public ApiResponse<QualityPolicy> getQuality(@PathVariable String polCd) {
         return ApiResponse.success(service.getQualityPolicy(polCd));
     }
 
     @PutMapping("/quality/policies/{polCd}")
+    @Operation(summary = "퀄리티 정책 등록/수정", description = "퀄리티 정책을 등록하거나 수정합니다")
     public ApiResponse<QualityPolicy> upsertQuality(@RequestHeader("X-USER-ID") Long uid,
                                                      @PathVariable String polCd,
                                                      @Valid @RequestBody QualityPolicyRequest req) {
@@ -64,11 +75,13 @@ public class AdminPolicyController {
 
     // Size policies
     @GetMapping("/size/policies")
+    @Operation(summary = "사이즈 정책 목록", description = "사이즈 정책 목록을 조회합니다")
     public ApiResponse<Iterable<SizePolicy>> listSize(@RequestParam String spcCd) {
         return ApiResponse.success(service.listSizePolicies(spcCd));
     }
 
     @PutMapping("/size/policies/{spcCd}/{szCd}")
+    @Operation(summary = "사이즈 정책 등록/수정", description = "사이즈 정책을 등록하거나 수정합니다")
     public ApiResponse<SizePolicy> upsertSize(@RequestHeader("X-USER-ID") Long uid,
                                                @PathVariable String spcCd, @PathVariable String szCd,
                                                @Valid @RequestBody SizePolicyRequest req) {
@@ -77,6 +90,7 @@ public class AdminPolicyController {
 
     @DeleteMapping("/size/policies/{spcCd}/{szCd}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "사이즈 정책 삭제", description = "사이즈 정책을 삭제합니다")
     public void deleteSize(@RequestHeader("X-USER-ID") Long uid,
                            @PathVariable String spcCd, @PathVariable String szCd) {
         service.deleteSizePolicy(spcCd, szCd, uid);

--- a/src/main/java/com/rbox/breeding/adapter/in/web/ClutchWebCtr.java
+++ b/src/main/java/com/rbox/breeding/adapter/in/web/ClutchWebCtr.java
@@ -24,16 +24,21 @@ import com.rbox.breeding.application.port.in.CreateClutchCommand;
 import com.rbox.breeding.application.port.in.UpdateClutchCommand;
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 클러치 관련 API.
  */
 @RestController
 @RequestMapping("/clutches")
 @RequiredArgsConstructor
+@Tag(name = "Clutch", description = "클러치 관련 API")
 public class ClutchWebCtr {
     private final ClutchUseCase useCase;
 
     @PostMapping
+    @Operation(summary = "클러치 생성", description = "새로운 클러치를 생성합니다")
     public ResponseEntity<ApiResponse<Map<String, Long>>> create(@Valid @RequestBody ClutchCreateReq req) {
         Long id = useCase.createClutch(new CreateClutchCommand(req.matId(), req.femObjId(), req.cltNo(), req.layYmd(),
                 req.eggCount()), 1L);
@@ -43,12 +48,14 @@ public class ClutchWebCtr {
     }
 
     @GetMapping
+    @Operation(summary = "클러치 목록 조회", description = "클러치 목록을 조회합니다")
     public ApiResponse<List<ClutchEntity>> list(@RequestParam Long femObjId,
             @RequestParam(required = false) String statCd) {
         return ApiResponse.success(useCase.listClutches(femObjId, statCd, 1L));
     }
 
     @PatchMapping("/{id}")
+    @Operation(summary = "클러치 수정", description = "클러치 정보를 수정합니다")
     public ApiResponse<Void> update(@PathVariable Long id, @RequestBody ClutchPatchReq req) {
         useCase.updateClutch(id, new UpdateClutchCommand(req.statCd(), req.chkYn(), req.layYmd()), 1L);
         return ApiResponse.success(null);

--- a/src/main/java/com/rbox/breeding/adapter/in/web/PairingWebCtr.java
+++ b/src/main/java/com/rbox/breeding/adapter/in/web/PairingWebCtr.java
@@ -21,16 +21,21 @@ import com.rbox.breeding.application.port.in.CreatePairingCommand;
 import com.rbox.breeding.application.port.in.PairingUseCase;
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 메이팅 관련 API.
  */
 @RestController
 @RequestMapping("/pairings")
 @RequiredArgsConstructor
+@Tag(name = "Pairing", description = "메이팅 관련 API")
 public class PairingWebCtr {
     private final PairingUseCase useCase;
 
     @PostMapping
+    @Operation(summary = "메이팅 생성", description = "새로운 메이팅 정보를 생성합니다")
     public ResponseEntity<ApiResponse<Map<String, Long>>> create(@Valid @RequestBody PairingCreateReq req) {
         Long id = useCase.createPairing(new CreatePairingCommand(req.femObjId(), req.malObjId(), req.matDt(), req.note()), 1L);
         Map<String, Long> data = new HashMap<>();
@@ -39,6 +44,7 @@ public class PairingWebCtr {
     }
 
     @GetMapping
+    @Operation(summary = "메이팅 목록 조회", description = "메이팅 목록을 조회합니다")
     public ApiResponse<List<PairingEntity>> list(@RequestParam Long femObjId) {
         return ApiResponse.success(useCase.listPairings(femObjId, 1L));
     }

--- a/src/main/java/com/rbox/dashboard/adapter/in/web/DashboardWebCtr.java
+++ b/src/main/java/com/rbox/dashboard/adapter/in/web/DashboardWebCtr.java
@@ -10,17 +10,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 사용자 대시보드 요약 API.
  */
 @RestController
 @RequestMapping("/dashboard")
+@Tag(name = "Dashboard", description = "사용자 대시보드 요약 API")
 public class DashboardWebCtr {
 
     /**
      * 오늘/이번주 처리해야 할 브리딩 작업 요약을 반환한다.
      */
     @GetMapping("/overview")
+    @Operation(summary = "대시보드 요약", description = "오늘과 이번주 브리딩 작업 요약을 반환합니다")
     public ApiResponse<Map<String, Object>> overview() {
         // TODO 실제 데이터 연동 필요
         Map<String, Integer> today = Map.of(

--- a/src/main/java/com/rbox/lineage/adapter/in/web/LineageWebCtr.java
+++ b/src/main/java/com/rbox/lineage/adapter/in/web/LineageWebCtr.java
@@ -12,16 +12,21 @@ import com.rbox.common.api.ApiResponse;
 import com.rbox.lineage.application.port.in.LineageGraph;
 import com.rbox.lineage.application.port.in.LineageUseCase;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 계보 조회 API 컨트롤러.
  */
 @RestController
 @RequestMapping("/lineage")
 @RequiredArgsConstructor
+@Tag(name = "Lineage", description = "계보 조회 API")
 public class LineageWebCtr {
     private final LineageUseCase useCase;
 
     @GetMapping("/{id}/ancestors")
+    @Operation(summary = "조상 계보 조회", description = "특정 개체의 조상 계보를 조회합니다")
     public ApiResponse<LineageGraph> ancestors(@PathVariable Long id,
             @RequestParam(name = "depth", defaultValue = "3") int depth) {
         // 데모용으로 uid=1 고정

--- a/src/main/java/com/rbox/market/auction/AuctionController.java
+++ b/src/main/java/com/rbox/market/auction/AuctionController.java
@@ -7,11 +7,15 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * REST controller exposing minimal auction APIs based on the spec.
  */
 @RestController
 @RequestMapping("/market/auctions")
+@Tag(name = "Auction", description = "경매 관련 API")
 public class AuctionController {
     private final AuctionService service;
     private final Clock clock;
@@ -28,6 +32,7 @@ public class AuctionController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "경매 생성", description = "새로운 경매를 생성합니다")
     public IdResponse create(@RequestHeader("X-USER-ID") String user,
                              @RequestBody AuctionCreateRequest req) {
         Auction auc = service.create(getUserId(user), req);
@@ -35,11 +40,13 @@ public class AuctionController {
     }
 
     @GetMapping
+    @Operation(summary = "경매 목록", description = "경매 목록을 조회합니다")
     public List<Auction> list() {
         return service.list();
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "경매 상세 조회", description = "경매 상세 정보를 조회합니다")
     public Auction get(@PathVariable Long id) {
         Auction auc = service.get(id);
         if (auc == null) throw new ResourceNotFound();
@@ -48,12 +55,14 @@ public class AuctionController {
 
     @PostMapping("/{id}/bids")
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "입찰", description = "경매에 입찰합니다")
     public Bid placeBid(@RequestHeader("X-USER-ID") String user,
                         @PathVariable Long id, @RequestBody BidRequest req) {
         return service.placeBid(id, getUserId(user), req.amount());
     }
 
     @GetMapping("/{id}/winner")
+    @Operation(summary = "낙찰자 조회", description = "경매의 낙찰자를 조회합니다")
     public AuctionWinner winner(@PathVariable Long id) {
         AuctionWinner w = service.getWinner(id);
         if (w == null) throw new ResourceNotFound();
@@ -61,12 +70,14 @@ public class AuctionController {
     }
 
     @PostMapping("/{id}/winner/pay")
+    @Operation(summary = "낙찰자 결제 처리", description = "낙찰자의 결제 정보를 처리합니다")
     public void pay(@PathVariable Long id, @RequestBody PayRequest req) {
         Instant paidAt = req.paidAt() != null ? req.paidAt() : clock.instant();
         service.markPaid(id, paidAt, req.txId());
     }
 
     @PostMapping("/{id}/winner/cancel")
+    @Operation(summary = "낙찰 취소", description = "경매 낙찰을 취소합니다")
     public void cancel(@PathVariable Long id, @RequestBody CancelRequest req) {
         service.cancel(id, req.reason());
     }

--- a/src/main/java/com/rbox/notification/adapter/in/web/NotificationWebCtr.java
+++ b/src/main/java/com/rbox/notification/adapter/in/web/NotificationWebCtr.java
@@ -11,11 +11,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 브리딩 관련 알림 요약 API.
  */
 @RestController
 @RequestMapping("/notifications")
+@Tag(name = "Notification", description = "브리딩 관련 알림 API")
 public class NotificationWebCtr {
 
     /**
@@ -25,6 +29,7 @@ public class NotificationWebCtr {
      * @return 알림 목록 및 페이지 정보
      */
     @GetMapping("/upcoming")
+    @Operation(summary = "다가오는 알림 목록", description = "로그인 사용자의 다가오는 알림을 조회합니다")
     public ApiResponse<List<Map<String, Object>>> upcoming(
             @RequestParam(name = "type", required = false) String type) {
         // TODO 실제 구현에서는 서비스/리포지토리 연동 필요

--- a/src/main/java/com/rbox/object/adapter/in/web/ObjectWebCtr.java
+++ b/src/main/java/com/rbox/object/adapter/in/web/ObjectWebCtr.java
@@ -28,12 +28,16 @@ import com.rbox.object.application.port.in.CreateObjectCommand;
 import com.rbox.object.application.port.in.ObjectUseCase;
 import com.rbox.object.application.port.in.UpdateObjectCommand;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 개체(Object) 관련 API를 제공하는 Web Controller.
  */
 @RestController
 @RequestMapping("/objects")
 @RequiredArgsConstructor
+@Tag(name = "Object", description = "개체 관련 API")
 public class ObjectWebCtr {
     private final ObjectUseCase useCase;
     private final QrCodeService qrCodeService;
@@ -44,6 +48,7 @@ public class ObjectWebCtr {
      * <p>출력: 생성된 개체 ID</p>
      */
     @PostMapping
+    @Operation(summary = "개체 생성", description = "새로운 개체를 생성합니다")
     public ApiResponse<Map<String, Long>> create(@Valid @RequestBody ObjectCreateReq req) {
         Long id = useCase.createObject(new CreateObjectCommand(req.spcCd(), req.name(), req.sexCd(), req.bthYmd()), 1L);
         Map<String, Long> data = new HashMap<>();
@@ -56,6 +61,7 @@ public class ObjectWebCtr {
      * <p>출력: 소유한 개체 리스트</p>
      */
     @GetMapping
+    @Operation(summary = "내 개체 목록 조회", description = "소유한 개체 목록을 조회합니다")
     public ApiResponse<List<ObjectEntity>> list() {
         return ApiResponse.success(useCase.listObjects(1L));
     }
@@ -65,6 +71,7 @@ public class ObjectWebCtr {
      * <p>필수 입력: 개체 ID</p>
      */
     @GetMapping("/{id}")
+    @Operation(summary = "개체 상세 조회", description = "개체 ID로 상세 정보를 조회합니다")
     public ApiResponse<ObjectEntity> get(@PathVariable Long id) {
         return ApiResponse.success(useCase.getObject(id, 1L));
     }
@@ -73,6 +80,7 @@ public class ObjectWebCtr {
      * 개체 정보 수정 API.
      */
     @PatchMapping("/{id}")
+    @Operation(summary = "개체 정보 수정", description = "개체 정보를 수정합니다")
     public ApiResponse<Void> update(@PathVariable Long id, @Valid @RequestBody ObjectUpdateReq req) {
         useCase.updateObject(id, new UpdateObjectCommand(req.name(), req.sexCd(), req.bthYmd()), 1L);
         return ApiResponse.success(null);
@@ -82,6 +90,7 @@ public class ObjectWebCtr {
      * 개체 삭제 API.
      */
     @DeleteMapping("/{id}")
+    @Operation(summary = "개체 삭제", description = "개체를 삭제합니다")
     public ApiResponse<Void> delete(@PathVariable Long id) {
         useCase.deleteObject(id, 1L);
         return ApiResponse.success(null);
@@ -91,6 +100,7 @@ public class ObjectWebCtr {
      * 개체 이미지 목록 조회 API.
      */
     @GetMapping("/{id}/images")
+    @Operation(summary = "개체 이미지 목록 조회", description = "개체 이미지 목록을 조회합니다")
     public ApiResponse<List<ObjectImageEntity>> listImages(@PathVariable Long id) {
         return ApiResponse.success(useCase.listImages(id, 1L));
     }
@@ -99,6 +109,7 @@ public class ObjectWebCtr {
      * QR code for object.
      */
     @GetMapping(value = "/{id}/qrcode")
+    @Operation(summary = "개체 QR 코드", description = "개체의 QR 코드를 생성합니다")
     public ResponseEntity<byte[]> qrcode(@PathVariable Long id,
             @RequestParam(required = false, defaultValue = "png") String fmt,
             @RequestParam(required = false, defaultValue = "256") Integer w) {
@@ -114,6 +125,7 @@ public class ObjectWebCtr {
      * 개체 이미지 추가 API.
      */
     @PostMapping("/{id}/images")
+    @Operation(summary = "개체 이미지 추가", description = "개체에 이미지를 추가합니다")
     public ApiResponse<Map<String, Long>> addImage(@PathVariable Long id, @Valid @RequestBody ObjectImageReq req) {
         Long imgId = useCase.addImage(id, new AddImageCommand(req.url(), req.ordNo()), 1L);
         return ApiResponse.success(Map.of("imgId", imgId));
@@ -123,6 +135,7 @@ public class ObjectWebCtr {
      * 개체 이미지 삭제 API.
      */
     @DeleteMapping("/{id}/images/{imgId}")
+    @Operation(summary = "개체 이미지 삭제", description = "개체 이미지를 삭제합니다")
     public ApiResponse<Void> deleteImage(@PathVariable Long id, @PathVariable Long imgId) {
         useCase.deleteImage(id, imgId, 1L);
         return ApiResponse.success(null);

--- a/src/main/java/com/rbox/org/v2/OrgV2Controller.java
+++ b/src/main/java/com/rbox/org/v2/OrgV2Controller.java
@@ -18,12 +18,16 @@ import lombok.RequiredArgsConstructor;
 
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * Controller for organization management APIs (v2).
  */
 @RestController
 @RequestMapping("/v2")
 @RequiredArgsConstructor
+@Tag(name = "Organization v2", description = "조직 관리 API v2")
 public class OrgV2Controller {
     private final OrgService service;
 
@@ -32,6 +36,7 @@ public class OrgV2Controller {
     }
 
     @PostMapping("/orgs")
+    @Operation(summary = "조직 생성", description = "새로운 조직을 생성합니다")
     public ApiResponse<Map<String, Long>> createOrg(@RequestHeader("X-USER-ID") String user,
             @RequestBody Map<String, String> body) {
         String orgNm = body.getOrDefault("orgNm", "");
@@ -41,12 +46,14 @@ public class OrgV2Controller {
     }
 
     @GetMapping("/orgs")
+    @Operation(summary = "조직 목록 조회", description = "사용자의 조직 목록을 조회합니다")
     public ApiResponse<List<OrgService.Org>> listOrgs(@RequestHeader("X-USER-ID") String user) {
         List<OrgService.Org> list = service.listOrgs(getUserId(user));
         return ApiResponse.success(list);
     }
 
     @PostMapping("/orgs/{orgId}/members")
+    @Operation(summary = "멤버 추가", description = "조직에 멤버를 추가합니다")
     public ApiResponse<Void> addMember(@PathVariable Long orgId, @RequestBody Map<String, Object> body) {
         Long userId = ((Number) body.get("userId")).longValue();
         String roleCd = (String) body.get("roleCd");
@@ -55,6 +62,7 @@ public class OrgV2Controller {
     }
 
     @PatchMapping("/orgs/{orgId}/members/{userId}")
+    @Operation(summary = "멤버 역할 변경", description = "조직 멤버의 역할을 변경합니다")
     public ApiResponse<Void> changeMember(@PathVariable Long orgId, @PathVariable Long userId,
             @RequestBody Map<String, String> body) {
         String roleCd = body.get("roleCd");
@@ -63,12 +71,14 @@ public class OrgV2Controller {
     }
 
     @DeleteMapping("/orgs/{orgId}/members/{userId}")
+    @Operation(summary = "멤버 삭제", description = "조직에서 멤버를 삭제합니다")
     public ApiResponse<Void> deleteMember(@PathVariable Long orgId, @PathVariable Long userId) {
         service.deleteMember(orgId, userId);
         return ApiResponse.success(null);
     }
 
     @GetMapping("/context")
+    @Operation(summary = "조직 컨텍스트 조회", description = "요청 헤더의 조직/사용자 정보를 반환합니다")
     public ApiResponse<Map<String, Object>> context(
             @RequestHeader(value = "X-USER-ID", required = false) String user,
             @RequestHeader(value = "X-RBOX-ORG-ID", required = false) String org) {

--- a/src/main/java/com/rbox/profile/adapter/in/web/ProfileWebCtr.java
+++ b/src/main/java/com/rbox/profile/adapter/in/web/ProfileWebCtr.java
@@ -23,29 +23,37 @@ import com.rbox.profile.application.port.in.ReviewPage;
 import com.rbox.profile.application.port.in.ReportReviewCommand;
 import com.rbox.profile.application.port.in.UpdateProfileCommand;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 @RestController
 @RequestMapping("/profiles")
 @RequiredArgsConstructor
+@Tag(name = "Profile", description = "프로필 관련 API")
 public class ProfileWebCtr {
     private final ProfileUseCase useCase;
 
     @GetMapping("/{userId}/public")
+    @Operation(summary = "공개 프로필 조회", description = "사용자의 공개 프로필을 조회합니다")
     public ApiResponse<ProfilePublic> getPublic(@PathVariable Long userId) {
         return ApiResponse.success(useCase.getPublicProfile(userId));
     }
 
     @GetMapping("/{userId}/summary")
+    @Operation(summary = "프로필 요약", description = "사용자의 프로필 요약 정보를 조회합니다")
     public ApiResponse<ProfileSummary> summary(@PathVariable Long userId) {
         return ApiResponse.success(useCase.getSummary(userId));
     }
 
     @PatchMapping("/me")
+    @Operation(summary = "내 프로필 수정", description = "내 프로필 정보를 수정합니다")
     public ApiResponse<Map<String, Boolean>> updateMe(@RequestBody UpdateProfileCommand command) {
         useCase.updateMyProfile(1L, command);
         return ApiResponse.success(Map.of("ok", true));
     }
 
     @GetMapping("/{userId}/reviews")
+    @Operation(summary = "리뷰 목록 조회", description = "사용자 리뷰 목록을 조회합니다")
     public ApiResponse<ReviewPage> listReviews(@PathVariable Long userId,
             @RequestParam(name = "page", defaultValue = "1") int page,
             @RequestParam(name = "size", defaultValue = "20") int size) {
@@ -53,6 +61,7 @@ public class ProfileWebCtr {
     }
 
     @PostMapping("/{userId}/reviews")
+    @Operation(summary = "리뷰 작성", description = "사용자에 대한 리뷰를 작성합니다")
     public ApiResponse<Map<String, Long>> createReview(@PathVariable Long userId,
             @RequestBody CreateReviewCommand command) {
         Long id = useCase.createReview(1L, userId, command);
@@ -60,12 +69,14 @@ public class ProfileWebCtr {
     }
 
     @PostMapping("/reviews/{id}/report")
+    @Operation(summary = "리뷰 신고", description = "리뷰를 신고합니다")
     public ApiResponse<Map<String, Long>> report(@PathVariable Long id, @RequestBody ReportReviewCommand command) {
         Long rptId = useCase.reportReview(id, 1L, command);
         return ApiResponse.success(Map.of("id", rptId));
     }
 
     @DeleteMapping("/reviews/{id}")
+    @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다")
     public ApiResponse<Void> delete(@PathVariable Long id) {
         useCase.deleteReview(id, 1L);
         return ApiResponse.success(null);

--- a/src/main/java/com/rbox/search/v2/SearchV2Controller.java
+++ b/src/main/java/com/rbox/search/v2/SearchV2Controller.java
@@ -12,16 +12,21 @@ import lombok.RequiredArgsConstructor;
 
 import com.rbox.common.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * Controller exposing the v2 search endpoints.
  */
 @RestController
 @RequestMapping("/v2/search")
 @RequiredArgsConstructor
+@Tag(name = "Search v2", description = "검색 API v2")
 public class SearchV2Controller {
     private final SearchService service;
 
     @GetMapping("/listings")
+    @Operation(summary = "리스트 검색", description = "리스트를 검색합니다")
     public ApiResponse<Map<String, Object>> listings(
             @RequestParam(required = false, defaultValue = "ALL") String type,
             @RequestParam(required = false) String spcCd,
@@ -52,6 +57,7 @@ public class SearchV2Controller {
     }
 
     @GetMapping("/objects")
+    @Operation(summary = "개체 검색", description = "개체를 검색합니다")
     public ApiResponse<Map<String, Object>> objects(
             @RequestParam(required = false) String spcCd,
             @RequestParam(required = false) String sexCd,

--- a/src/main/java/com/rbox/snapshot/adapter/in/web/SnapshotWebCtr.java
+++ b/src/main/java/com/rbox/snapshot/adapter/in/web/SnapshotWebCtr.java
@@ -21,17 +21,22 @@ import com.rbox.snapshot.application.port.in.SnapshotCreateResp;
 import com.rbox.snapshot.application.port.in.SnapshotUseCase;
 import com.rbox.common.qr.QrCodeService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * 3세대 계보 스냅샷 API.
  */
 @RestController
 @RequestMapping("/snapshots/3gen")
 @RequiredArgsConstructor
+@Tag(name = "Snapshot", description = "3세대 계보 스냅샷 API")
 public class SnapshotWebCtr {
     private final SnapshotUseCase useCase;
     private final QrCodeService qrCodeService;
 
     @PostMapping
+    @Operation(summary = "스냅샷 생성", description = "3세대 계보 스냅샷을 생성합니다")
     public ResponseEntity<ApiResponse<SnapshotCreateResp>> create(@Valid @RequestBody SnapshotCreateReq req) {
         SnapshotCreateResp resp = useCase.createSnapshot(
                 new SnapshotCreateCommand(req.rootObjId(), req.ttlDays(), req.note()), 1L);
@@ -39,6 +44,7 @@ public class SnapshotWebCtr {
     }
 
     @GetMapping("/{token}")
+    @Operation(summary = "스냅샷 조회", description = "토큰으로 스냅샷을 조회합니다")
     public ApiResponse<LineageGraph> get(@PathVariable String token) {
         return ApiResponse.success(useCase.getSnapshot(token));
     }
@@ -47,6 +53,7 @@ public class SnapshotWebCtr {
      * QR code for snapshot token.
      */
     @GetMapping("/{token}/qrcode")
+    @Operation(summary = "스냅샷 QR 코드", description = "스냅샷 토큰의 QR 코드를 생성합니다")
     public ResponseEntity<byte[]> qrcode(@PathVariable String token,
             @RequestParam(required = false, defaultValue = "png") String fmt,
             @RequestParam(required = false, defaultValue = "256") Integer w) {

--- a/src/main/java/com/rbox/system/adapter/in/web/HealthCheckWebCtr.java
+++ b/src/main/java/com/rbox/system/adapter/in/web/HealthCheckWebCtr.java
@@ -5,6 +5,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import com.rbox.system.application.port.in.HealthCheckUseCase;
 import com.rbox.system.application.port.in.ServerHealthCheckCommand;
 import com.rbox.system.application.port.in.DbHealthCheckCommand;
@@ -15,6 +18,7 @@ import com.rbox.system.application.port.in.DbHealthCheckCommand;
 @RestController
 @RequestMapping("/health")
 @RequiredArgsConstructor
+@Tag(name = "Health Check", description = "시스템 헬스 체크 API")
 public class HealthCheckWebCtr {
     private final HealthCheckUseCase useCase;
 
@@ -24,6 +28,7 @@ public class HealthCheckWebCtr {
      * <p>출력: 서버 상태를 나타내는 {@link HealthCheckRes}</p>
      */
     @GetMapping("/server")
+    @Operation(summary = "서버 상태 확인", description = "서버의 상태를 확인합니다")
     public HealthCheckRes server(ServerHealthCheckReq req) {
         return useCase.checkServerHealth(new ServerHealthCheckCommand());
     }
@@ -34,6 +39,7 @@ public class HealthCheckWebCtr {
      * <p>출력: DB 상태를 나타내는 {@link HealthCheckRes}</p>
      */
     @GetMapping("/db")
+    @Operation(summary = "DB 연결 상태 확인", description = "데이터베이스 연결 상태를 확인합니다")
     public HealthCheckRes db(DbHealthCheckReq req) {
         return useCase.checkDbHealth(new DbHealthCheckCommand());
     }

--- a/src/main/java/com/rbox/user/adapter/in/web/UserWebCtr.java
+++ b/src/main/java/com/rbox/user/adapter/in/web/UserWebCtr.java
@@ -4,6 +4,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import lombok.RequiredArgsConstructor;
 
 import com.rbox.common.api.ApiResponse;
@@ -16,6 +19,7 @@ import com.rbox.user.application.port.in.UserUseCase;
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
+@Tag(name = "User", description = "사용자 관련 API")
 public class UserWebCtr {
     private final UserUseCase useCase;
 
@@ -25,6 +29,7 @@ public class UserWebCtr {
      * <p>출력: 사용자 기본 정보 {@link UserMe}</p>
      */
     @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "인증 정보를 이용하여 내 정보를 조회합니다")
     public ApiResponse<UserMe> me() {
         return ApiResponse.success(useCase.getMe(1L));
     }


### PR DESCRIPTION
## Summary
- annotate all REST controllers with Swagger `@Tag` and `@Operation` so APIs appear in documentation

## Testing
- `gradle test` *(fails: Could not resolve org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be7570a828832ea39f1f29c6555d00