### PR TITLE
feat: add object v2 creation endpoint and refine org/search APIs

### DIFF
--- a/openapi-search-orgs-v2.yaml
+++ b/openapi-search-orgs-v2.yaml
@@ -146,6 +146,43 @@ paths:
                 roleCd: { type: string, enum: [OWNER, ADMIN, EDITOR, VIEWER] }
       responses: { '201': { description: Added } }
 
+  /v2/orgs/{orgId}/members/{userId}:
+    patch:
+      tags: [Orgs]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: orgId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: path
+          name: userId
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [roleCd]
+              properties:
+                roleCd: { type: string, enum: [OWNER, ADMIN, EDITOR, VIEWER] }
+      responses: { '200': { description: Updated } }
+    delete:
+      tags: [Orgs]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: orgId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: path
+          name: userId
+          required: true
+          schema: { type: integer, format: int64 }
+      responses: { '200': { description: Deleted } }
+
   /v2/context:
     get:
       tags: [Orgs]

--- a/src/main/java/com/rbox/object/v2/ObjectCreateReq.java
+++ b/src/main/java/com/rbox/object/v2/ObjectCreateReq.java
@@ -1,0 +1,12 @@
+package com.rbox.object.v2;
+
+/**
+ * Request body for creating an object in the v2 API.
+ * Only spcCd and sexCd are required.
+ */
+public record ObjectCreateReq(
+        String spcCd,
+        String name,
+        String sexCd,
+        String ownerType
+) {}

--- a/src/main/java/com/rbox/object/v2/ObjectService.java
+++ b/src/main/java/com/rbox/object/v2/ObjectService.java
@@ -1,0 +1,24 @@
+package com.rbox.object.v2;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Very light in-memory service to back the v2 object API.
+ */
+@Service
+public class ObjectService {
+    private final AtomicLong seq = new AtomicLong(1);
+    private final Map<Long, Object> objects = new ConcurrentHashMap<>();
+
+    public Long createObject(String spcCd, String name, String sexCd, String ownerType, Long orgId) {
+        long id = seq.getAndIncrement();
+        objects.put(id, new Object(id, spcCd, name, sexCd, ownerType, orgId));
+        return id;
+    }
+
+    public record Object(Long objId, String spcCd, String name, String sexCd, String ownerType, Long orgId) {}
+}

--- a/src/main/java/com/rbox/object/v2/ObjectV2WebCtr.java
+++ b/src/main/java/com/rbox/object/v2/ObjectV2WebCtr.java
@@ -1,0 +1,36 @@
+package com.rbox.object.v2;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.rbox.common.api.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Controller exposing the v2 object endpoints.
+ */
+@RestController
+@RequestMapping("/v2")
+@RequiredArgsConstructor
+@Tag(name = "Object v2", description = "개체 API v2")
+public class ObjectV2WebCtr {
+    private final ObjectService service;
+
+    @PostMapping("/objects")
+    @Operation(summary = "개체 생성", description = "새로운 개체를 생성합니다")
+    public ApiResponse<Map<String, Long>> create(
+            @RequestHeader(value = "X-RBOX-ORG-ID", required = false) Long orgId,
+            @RequestBody ObjectCreateReq req) {
+        Long id = service.createObject(req.spcCd(), req.name(), req.sexCd(), req.ownerType(), orgId);
+        return ApiResponse.success(Map.of("objId", id));
+    }
+}

--- a/src/main/java/com/rbox/org/v2/OrgCreateReq.java
+++ b/src/main/java/com/rbox/org/v2/OrgCreateReq.java
@@ -1,0 +1,9 @@
+package com.rbox.org.v2;
+
+/**
+ * Request body for creating an organization in v2 APIs.
+ */
+public record OrgCreateReq(
+        String orgNm,
+        String orgTp) {
+}

--- a/src/main/java/com/rbox/org/v2/OrgMemberAddReq.java
+++ b/src/main/java/com/rbox/org/v2/OrgMemberAddReq.java
@@ -1,0 +1,9 @@
+package com.rbox.org.v2;
+
+/**
+ * Request body for adding a member to an organization.
+ */
+public record OrgMemberAddReq(
+        Long userId,
+        String roleCd) {
+}

--- a/src/main/java/com/rbox/org/v2/OrgMemberRoleReq.java
+++ b/src/main/java/com/rbox/org/v2/OrgMemberRoleReq.java
@@ -1,0 +1,8 @@
+package com.rbox.org.v2;
+
+/**
+ * Request body for changing a member's role.
+ */
+public record OrgMemberRoleReq(
+        String roleCd) {
+}

--- a/src/main/java/com/rbox/org/v2/OrgV2WebCtr.java
+++ b/src/main/java/com/rbox/org/v2/OrgV2WebCtr.java
@@ -38,9 +38,9 @@ public class OrgV2WebCtr {
     @PostMapping("/orgs")
     @Operation(summary = "조직 생성", description = "새로운 조직을 생성합니다")
     public ApiResponse<Map<String, Long>> createOrg(@RequestHeader("X-USER-ID") String user,
-            @RequestBody Map<String, String> body) {
-        String orgNm = body.getOrDefault("orgNm", "");
-        String orgTp = body.getOrDefault("orgTp", "SHOP");
+            @RequestBody OrgCreateReq body) {
+        String orgNm = body.orgNm();
+        String orgTp = body.orgTp() == null ? "SHOP" : body.orgTp();
         OrgService.Org org = service.createOrg(getUserId(user), orgNm, orgTp);
         return ApiResponse.success(Map.of("orgId", org.orgId()));
     }
@@ -54,19 +54,16 @@ public class OrgV2WebCtr {
 
     @PostMapping("/orgs/{orgId}/members")
     @Operation(summary = "멤버 추가", description = "조직에 멤버를 추가합니다")
-    public ApiResponse<Void> addMember(@PathVariable Long orgId, @RequestBody Map<String, Object> body) {
-        Long userId = ((Number) body.get("userId")).longValue();
-        String roleCd = (String) body.get("roleCd");
-        service.addMember(orgId, userId, roleCd);
+    public ApiResponse<Void> addMember(@PathVariable Long orgId, @RequestBody OrgMemberAddReq body) {
+        service.addMember(orgId, body.userId(), body.roleCd());
         return ApiResponse.success(null);
     }
 
     @PatchMapping("/orgs/{orgId}/members/{userId}")
     @Operation(summary = "멤버 역할 변경", description = "조직 멤버의 역할을 변경합니다")
     public ApiResponse<Void> changeMember(@PathVariable Long orgId, @PathVariable Long userId,
-            @RequestBody Map<String, String> body) {
-        String roleCd = body.get("roleCd");
-        service.changeMember(orgId, userId, roleCd);
+            @RequestBody OrgMemberRoleReq body) {
+        service.changeMember(orgId, userId, body.roleCd());
         return ApiResponse.success(null);
     }
 

--- a/src/main/java/com/rbox/search/v2/SearchV2WebCtr.java
+++ b/src/main/java/com/rbox/search/v2/SearchV2WebCtr.java
@@ -1,7 +1,5 @@
 package com.rbox.search.v2;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.rbox.common.api.ApiResponse;
+import com.rbox.search.v2.SearchService.SearchResult;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,7 +26,7 @@ public class SearchV2WebCtr {
 
     @GetMapping("/listings")
     @Operation(summary = "리스트 검색", description = "리스트를 검색합니다")
-    public ApiResponse<Map<String, Object>> listings(
+    public ApiResponse<SearchResult> listings(
             @RequestParam(required = false, defaultValue = "ALL") String type,
             @RequestParam(required = false) String spcCd,
             @RequestParam(required = false) String sexCd,
@@ -47,18 +46,13 @@ public class SearchV2WebCtr {
                 priceMin == null ? null : java.math.BigDecimal.valueOf(priceMin),
                 priceMax == null ? null : java.math.BigDecimal.valueOf(priceMax),
                 morphMode, morphCat, morphIds, hasImage, ownerUserId, ownerOrgId, sort, page, size);
-        SearchService.SearchResult result = service.searchListings(req);
-        Map<String, Object> data = new HashMap<>();
-        data.put("content", result.content());
-        data.put("total", result.total());
-        data.put("page", result.page());
-        data.put("size", result.size());
-        return ApiResponse.success(data);
+        SearchResult result = service.searchListings(req);
+        return ApiResponse.success(result);
     }
 
     @GetMapping("/objects")
     @Operation(summary = "개체 검색", description = "개체를 검색합니다")
-    public ApiResponse<Map<String, Object>> objects(
+    public ApiResponse<SearchResult> objects(
             @RequestParam(required = false) String spcCd,
             @RequestParam(required = false) String sexCd,
             @RequestParam(required = false) String sizeCd,
@@ -68,13 +62,8 @@ public class SearchV2WebCtr {
             @RequestParam(required = false, defaultValue = "1") Integer page,
             @RequestParam(required = false, defaultValue = "20") Integer size) {
         SearchObjectsReq req = new SearchObjectsReq(spcCd, sexCd, sizeCd, morphMode, morphIds, sort, page, size);
-        SearchService.SearchResult result = service.searchObjects(req);
-        Map<String, Object> data = new HashMap<>();
-        data.put("content", result.content());
-        data.put("total", result.total());
-        data.put("page", result.page());
-        data.put("size", result.size());
-        return ApiResponse.success(data);
+        SearchResult result = service.searchObjects(req);
+        return ApiResponse.success(result);
     }
 }
 


### PR DESCRIPTION
## Summary
- add request records and controllers for v2 org endpoints
- return structured search results from v2 search endpoints
- expose in-memory object creation service and controller for /v2/objects

## Testing
- `gradle test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.2.2, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ecf3438832e9f311b39065605e3