### PR TITLE
feat: add global logging with logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'com.google.zxing:core:3.5.3'
     implementation 'com.google.zxing:javase:3.5.3'

--- a/src/main/java/com/rbox/common/logging/LoggingAspect.java
+++ b/src/main/java/com/rbox/common/logging/LoggingAspect.java
@@ -1,0 +1,44 @@
+package com.rbox.common.logging;
+
+import java.util.Arrays;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple AOP based logger that traces entry, exit and exceptions
+ * for controllers, services and repositories.
+ */
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingAspect.class);
+
+    @Around("within(@org.springframework.web.bind.annotation.RestController *)")
+    public Object logController(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logAround(joinPoint, "Controller");
+    }
+
+    @Around("within(@org.springframework.stereotype.Service *) || within(@org.springframework.stereotype.Repository *)")
+    public Object logService(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logAround(joinPoint, "Service");
+    }
+
+    private Object logAround(ProceedingJoinPoint joinPoint, String layer) throws Throwable {
+        String methodName = joinPoint.getSignature().toShortString();
+        log.info("[{}] Enter {} with args {}", layer, methodName, Arrays.toString(joinPoint.getArgs()));
+        try {
+            Object result = joinPoint.proceed();
+            log.info("[{}] Exit {} with result {}", layer, methodName, result);
+            return result;
+        } catch (Throwable e) {
+            log.error("[{}] Exception in {}", layer, methodName, e);
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- log controller and service method entry, exit and exceptions via AOP
- configure Logback console appender and pattern
- include Spring Boot AOP starter

## Testing
- `gradle test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-aop:3.2.2, received status code 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68bf743ca8f4832e8997aca0970abd4a