### PR TITLE
feat: add trace id logging for request tracing

### DIFF
--- a/src/main/java/com/rbox/common/logging/LoggingAspect.java
+++ b/src/main/java/com/rbox/common/logging/LoggingAspect.java
@@ -7,6 +7,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 /**
@@ -31,13 +32,15 @@ public class LoggingAspect {
 
     private Object logAround(ProceedingJoinPoint joinPoint, String layer) throws Throwable {
         String methodName = joinPoint.getSignature().toShortString();
-        log.info("[{}] Enter {} with args {}", layer, methodName, Arrays.toString(joinPoint.getArgs()));
+        String traceId = MDC.get(TraceIdFilter.TRACE_ID_KEY);
+        log.info("[{}][traceId={}] Enter {} with args {}", layer, traceId, methodName,
+            Arrays.toString(joinPoint.getArgs()));
         try {
             Object result = joinPoint.proceed();
-            log.info("[{}] Exit {} with result {}", layer, methodName, result);
+            log.info("[{}][traceId={}] Exit {} with result {}", layer, traceId, methodName, result);
             return result;
         } catch (Throwable e) {
-            log.error("[{}] Exception in {}", layer, methodName, e);
+            log.error("[{}][traceId={}] Exception in {}", layer, traceId, methodName, e);
             throw e;
         }
     }

--- a/src/main/java/com/rbox/common/logging/TraceIdFilter.java
+++ b/src/main/java/com/rbox/common/logging/TraceIdFilter.java
@@ -1,0 +1,50 @@
+package com.rbox.common.logging;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter that assigns a trace identifier for each incoming request and
+ * logs basic request information. The identifier is added to the MDC so
+ * that it can be included in subsequent log messages, allowing requests
+ * to be traced even under heavy load.
+ */
+@Component
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    public static final String TRACE_ID_KEY = "traceId";
+
+    private static final Logger log = LoggerFactory.getLogger(TraceIdFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String traceId = obtainTraceId(request);
+        MDC.put(TRACE_ID_KEY, traceId);
+        log.info("[traceId={}] Incoming request {} {} from {}", traceId,
+                request.getMethod(), request.getRequestURI(), request.getRemoteAddr());
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID_KEY);
+        }
+    }
+
+    private String obtainTraceId(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        return (session != null) ? session.getId() : UUID.randomUUID().toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add TraceIdFilter to generate per-request trace identifiers and log request origin
- include trace IDs in LoggingAspect messages for controllers and services

## Testing
- `gradle test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-aop:3.2.2. Received status code 403)*
- `mvn -q test` *(fails: Non-resolvable parent POM for com.rbox:system:0.0.1-SNAPSHOT. Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7561d454832e8d83086b04f14b35