### PR TITLE
Enable SQL query and parameter logging

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,5 @@ spring:
       mode: never
 mybatis:
   mapper-locations: classpath:mybatis/**/*.xml
+  configuration:
+    log-impl: org.apache.ibatis.logging.slf4j.Slf4jImpl

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,6 +8,8 @@
         </encoder>
     </appender>
 
+    <logger name="com.rbox" level="DEBUG"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
## Summary
- Configure MyBatis to use SLF4J logging implementation so SQL statements are logged
- Add a Logback logger for the `com.rbox` package at DEBUG level

## Testing
- `gradle test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-aop:3.2.2; Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7af1b2b8832e97eb55e44f522e82