### PR TITLE
Use constructor mapping for record entities

### DIFF
--- a/src/main/resources/mybatis/breeding/ClutchRepository.xml
+++ b/src/main/resources/mybatis/breeding/ClutchRepository.xml
@@ -2,14 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.rbox.breeding.adapter.out.persistence.repository.ClutchRepository">
   <resultMap id="ClutchMap" type="com.rbox.breeding.adapter.out.persistence.repository.ClutchEntity">
-    <id property="id" column="clt_id" />
-    <result property="matId" column="mat_id" />
-    <result property="femObjId" column="fem_obj_id" />
-    <result property="cltNo" column="clt_no" />
-    <result property="layYmd" column="lay_ymd" />
-    <result property="eggCount" column="egg_count" />
-    <result property="statCd" column="stat_cd" />
-    <result property="chkYn" column="chk_yn" />
+    <constructor>
+      <idArg column="clt_id" javaType="java.lang.Long" />
+      <arg column="mat_id" javaType="java.lang.Long" />
+      <arg column="fem_obj_id" javaType="java.lang.Long" />
+      <arg column="clt_no" javaType="java.lang.Integer" />
+      <arg column="lay_ymd" javaType="java.lang.String" />
+      <arg column="egg_count" javaType="java.lang.Integer" />
+      <arg column="stat_cd" javaType="java.lang.String" />
+      <arg column="chk_yn" javaType="java.lang.String" />
+    </constructor>
   </resultMap>
 
   <insert id="save" parameterType="com.rbox.breeding.adapter.out.persistence.repository.ClutchEntity" useGeneratedKeys="true" keyProperty="id" keyColumn="clt_id">

--- a/src/main/resources/mybatis/breeding/PairingRepository.xml
+++ b/src/main/resources/mybatis/breeding/PairingRepository.xml
@@ -2,12 +2,14 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.rbox.breeding.adapter.out.persistence.repository.PairingRepository">
   <resultMap id="PairingMap" type="com.rbox.breeding.adapter.out.persistence.repository.PairingEntity">
-    <id property="id" column="mat_id" />
-    <result property="femObjId" column="fem_obj_id" />
-    <result property="malObjId" column="mal_obj_id" />
-    <result property="matDt" column="mat_dt" />
-    <result property="statCd" column="stat_cd" />
-    <result property="note" column="note" />
+    <constructor>
+      <idArg column="mat_id" javaType="java.lang.Long" />
+      <arg column="fem_obj_id" javaType="java.lang.Long" />
+      <arg column="mal_obj_id" javaType="java.lang.Long" />
+      <arg column="mat_dt" javaType="java.lang.String" />
+      <arg column="stat_cd" javaType="java.lang.String" />
+      <arg column="note" javaType="java.lang.String" />
+    </constructor>
   </resultMap>
 
   <insert id="save" parameterType="com.rbox.breeding.adapter.out.persistence.repository.PairingEntity" useGeneratedKeys="true" keyProperty="id" keyColumn="mat_id">

--- a/src/main/resources/mybatis/object/ObjectImageRepository.xml
+++ b/src/main/resources/mybatis/object/ObjectImageRepository.xml
@@ -2,10 +2,12 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.rbox.object.adapter.out.persistence.repository.ObjectImageRepository">
   <resultMap id="ObjectImageMap" type="com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity">
-    <id property="imgId" column="img_id" />
-    <result property="objId" column="obj_id" />
-    <result property="url" column="url" />
-    <result property="ordNo" column="ord_no" />
+    <constructor>
+      <idArg column="img_id" javaType="java.lang.Long" />
+      <arg column="obj_id" javaType="java.lang.Long" />
+      <arg column="url" javaType="java.lang.String" />
+      <arg column="ord_no" javaType="int" />
+    </constructor>
   </resultMap>
 
   <insert id="save" parameterType="com.rbox.object.adapter.out.persistence.repository.ObjectImageEntity" useGeneratedKeys="true" keyProperty="imgId" keyColumn="img_id">

--- a/src/main/resources/mybatis/object/ObjectRepository.xml
+++ b/src/main/resources/mybatis/object/ObjectRepository.xml
@@ -2,15 +2,17 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.rbox.object.adapter.out.persistence.repository.ObjectRepository">
   <resultMap id="ObjectMap" type="com.rbox.object.adapter.out.persistence.repository.ObjectEntity">
-    <id property="id" column="obj_id" />
-    <result property="spcCd" column="spc_cd" />
-    <result property="name" column="name" />
-    <result property="sexCd" column="sex_cd" />
-    <result property="bthYmd" column="bth_ymd" />
-    <result property="objMode" column="obj_mode" />
-    <result property="statCd" column="stat_cd" />
-    <result property="marketOk" column="market_ok" />
-    <result property="ownUsrId" column="own_usr_id" />
+    <constructor>
+      <idArg column="obj_id" javaType="java.lang.Long" />
+      <arg column="spc_cd" javaType="java.lang.String" />
+      <arg column="name" javaType="java.lang.String" />
+      <arg column="sex_cd" javaType="java.lang.String" />
+      <arg column="bth_ymd" javaType="java.lang.String" />
+      <arg column="obj_mode" javaType="java.lang.String" />
+      <arg column="stat_cd" javaType="java.lang.String" />
+      <arg column="market_ok" javaType="java.lang.String" />
+      <arg column="own_usr_id" javaType="java.lang.Long" />
+    </constructor>
   </resultMap>
 
   <insert id="save" parameterType="com.rbox.object.adapter.out.persistence.repository.ObjectEntity" useGeneratedKeys="true" keyProperty="id" keyColumn="obj_id">

--- a/src/main/resources/mybatis/user/UserRepository.xml
+++ b/src/main/resources/mybatis/user/UserRepository.xml
@@ -2,11 +2,13 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.rbox.user.adapter.out.persistence.repository.UserRepository">
   <resultMap id="UserMap" type="com.rbox.user.adapter.out.persistence.repository.UserEntity">
-    <id property="id" column="usr_id" />
-    <result property="email" column="email" />
-    <result property="nick" column="nick" />
-    <result property="stat" column="stat_cd" />
-    <result property="password" column="pwd" />
+    <constructor>
+      <idArg column="usr_id" javaType="java.lang.Long" />
+      <arg column="email" javaType="java.lang.String" />
+      <arg column="nick" javaType="java.lang.String" />
+      <arg column="stat_cd" javaType="java.lang.String" />
+      <arg column="pwd" javaType="java.lang.String" />
+    </constructor>
   </resultMap>
 
   <!-- 이메일로 사용자 조회 -->


### PR DESCRIPTION
## Summary
- map MyBatis result sets to Java records using constructor mapping to avoid setter requirement
- apply constructor-based resultMaps across user, breeding and object repositories

## Testing
- `gradle test` *(fails: Could not resolve all files for configuration ':compileClasspath'. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8082be30832e9f5625874bfc020a