### PR TITLE
Add Swagger header token configuration

### DIFF
--- a/src/main/java/com/rbox/common/config/OpenApiConfig.java
+++ b/src/main/java/com/rbox/common/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.rbox.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+/**
+ * OpenAPI configuration for Swagger UI.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name(SECURITY_SCHEME_NAME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+}


### PR DESCRIPTION
## Summary
- add OpenAPI configuration so Swagger UI supports JWT bearer tokens

## Testing
- `gradle test` *(fails: Could not resolve io.jsonwebtoken:jjwt-api:0.11.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa9d92fa8832e9da0dba9a3a60baa